### PR TITLE
STYLE: Improve attribution by ignoring bulk formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,20 @@
+#
+# This file lists revisions that should be ignored when considering
+# attribution for the actual code written.  Code style changes should
+# not be considered as modifications with regards to attribution.
+#
+# To see clean and meaningful blame information.
+# $ git blame important.py --ignore-revs-file .git-blame-ignore-revs
+#
+# To configure git to automatically ignore revisions listed in a file on every call to git blame.
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Ignore changes introduced when doing global file format changes
+# STYLE: Remove trailing spaces from cmake files
+7765bd04df336d115e9ccb8187fd42175d3c6ccc
+# STYLE: Convert CMake-language commands to lower case
+d6ea8ed817d1c77e202344040848ab3fa6ab6467
+# STYLE: Remove CMake-language block-end command arguments
+4634aae00cd89dfb55568d3cbf322185829771a1
+# STYLE: Fix line endings to be consistent
+36e8b77c62b5e69cfddfc9cd77f5e522fe11edd0


### PR DESCRIPTION
This file lists revisions that should be ignored when considering
attribution for the actual code written.  Code style changes should
not be considered as modifications with regards to attribution.

To see clean and meaningful blame information.
$ git blame important.py --ignore-revs-file .git-blame-ignore-revs

To configure git to automatically ignore revisions listed in a file on every call to git blame.
$ git config blame.ignoreRevsFile .git-blame-ignore-revs

Based on https://github.com/InsightSoftwareConsortium/ITK/commit/3a969e556af074614f75eeb59befbe83e410b47c
and https://github.com/Slicer/Slicer/commit/ec82a93f0c310d0c4508045bd3e934f53c7d2d12.