### PR TITLE
COMP: Update install rules to support custom install destination

### DIFF
--- a/CMake/AutoscoperInstallQt.cmake
+++ b/CMake/AutoscoperInstallQt.cmake
@@ -7,6 +7,7 @@ if(WIN32)
       ${_qt5Core_install_prefix}/bin/Qt5Core.dll
       ${_qt5Core_install_prefix}/bin/Qt5Network.dll
     DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release
+    COMPONENT Runtime
   )
   install(
     FILES
@@ -16,15 +17,18 @@ if(WIN32)
       ${_qt5Core_install_prefix}/bin/Qt5Cored.dll
       ${_qt5Core_install_prefix}/bin/Qt5Networkd.dll
     DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug
+    COMPONENT Runtime
   )
   install(
     FILES
       ${_qt5Core_install_prefix}/plugins/platforms/qwindows.dll
     DESTINATION ${Autoscoper_BIN_DIR}/Release/platforms CONFIGURATIONS Release
+    COMPONENT Runtime
   )
   install(
     FILES
       ${_qt5Core_install_prefix}/plugins/platforms/qwindowsd.dll
     DESTINATION ${Autoscoper_BIN_DIR}/Debug/platforms CONFIGURATIONS Debug
+    COMPONENT Runtime
   )
 endif()

--- a/CMake/AutoscoperInstallQt.cmake
+++ b/CMake/AutoscoperInstallQt.cmake
@@ -6,7 +6,7 @@ if(WIN32)
       ${_qt5Core_install_prefix}/bin/Qt5Gui.dll
       ${_qt5Core_install_prefix}/bin/Qt5Core.dll
       ${_qt5Core_install_prefix}/bin/Qt5Network.dll
-    DESTINATION bin/Release CONFIGURATIONS Release
+    DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release
   )
   install(
     FILES
@@ -15,16 +15,16 @@ if(WIN32)
       ${_qt5Core_install_prefix}/bin/Qt5Guid.dll
       ${_qt5Core_install_prefix}/bin/Qt5Cored.dll
       ${_qt5Core_install_prefix}/bin/Qt5Networkd.dll
-    DESTINATION bin/Debug CONFIGURATIONS Debug
+    DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug
   )
   install(
     FILES
       ${_qt5Core_install_prefix}/plugins/platforms/qwindows.dll
-    DESTINATION bin/Release/platforms CONFIGURATIONS Release
+    DESTINATION ${Autoscoper_BIN_DIR}/Release/platforms CONFIGURATIONS Release
   )
   install(
     FILES
       ${_qt5Core_install_prefix}/plugins/platforms/qwindowsd.dll
-    DESTINATION bin/Debug/platforms CONFIGURATIONS Debug
+    DESTINATION ${Autoscoper_BIN_DIR}/Debug/platforms CONFIGURATIONS Debug
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,8 @@ if(WIN32)
     file(GLOB external_dllsd "${Autoscoper_SUPERBUILD_DIR}/${dependency}-install/bin/*d.dll")
     list(REMOVE_ITEM external_dlls ${external_dllsd})
 
-    install(FILES ${external_dlls} DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release)
-    install(FILES ${external_dllsd} DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug)
+    install(FILES ${external_dlls} DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release COMPONENT Runtime)
+    install(FILES ${external_dllsd} DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug COMPONENT Runtime)
   endforeach()
 
   file(COPY sample_data DESTINATION ${CMAKE_INSTALL_PREFIX}/${Autoscoper_BIN_DIR}/Release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,13 +93,13 @@ if(WIN32)
     file(GLOB external_dllsd "${Autoscoper_SUPERBUILD_DIR}/${dependency}-install/bin/*d.dll")
     list(REMOVE_ITEM external_dlls ${external_dllsd})
 
-    install(FILES ${external_dlls} DESTINATION bin/Release CONFIGURATIONS Release)
-    install(FILES ${external_dllsd} DESTINATION bin/Debug CONFIGURATIONS Debug)
+    install(FILES ${external_dlls} DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release)
+    install(FILES ${external_dllsd} DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug)
   endforeach()
 
-  file(COPY sample_data DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/Release)
+  file(COPY sample_data DESTINATION ${CMAKE_INSTALL_PREFIX}/${Autoscoper_BIN_DIR}/Release)
 endif()
 
 if(UNIX)
-  file(COPY sample_data DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+  file(COPY sample_data DESTINATION ${CMAKE_INSTALL_PREFIX}/${Autoscoper_BIN_DIR})
 endif()

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -143,8 +143,8 @@ find_package(GLEW REQUIRED CONFIG)
 target_link_libraries(autoscoper PUBLIC GLEW::GLEW)
 target_compile_definitions(autoscoper PUBLIC -DUSE_GLEW)
 
-install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug)
-install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release)
+install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug COMPONENT Runtime)
+install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release COMPONENT Runtime)
 include("${Autoscoper_SOURCE_DIR}/CMake/AutoscoperInstallQt.cmake")
 
 if(APPLE)

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -143,11 +143,11 @@ find_package(GLEW REQUIRED CONFIG)
 target_link_libraries(autoscoper PUBLIC GLEW::GLEW)
 target_compile_definitions(autoscoper PUBLIC -DUSE_GLEW)
 
-install(TARGETS autoscoper DESTINATION bin/Debug CONFIGURATIONS Debug)
-install(TARGETS autoscoper DESTINATION bin/Release CONFIGURATIONS Release)
+install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug)
+install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release)
 include("${Autoscoper_SOURCE_DIR}/CMake/AutoscoperInstallQt.cmake")
 
 if(APPLE)
-  file(COPY ../sample_data DESTINATION ../bin/Debug/autoscoper.app/Contents/MacOS)
+  file(COPY ../sample_data DESTINATION ../${Autoscoper_BIN_DIR}/Debug/autoscoper.app/Contents/MacOS)
 endif()
 

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -61,5 +61,9 @@ target_include_directories(libautoscoper PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-install(TARGETS libautoscoper DESTINATION ${Autoscoper_LIB_DIR})
+install(TARGETS libautoscoper
+  RUNTIME DESTINATION ${Autoscoper_BIN_DIR} COMPONENT Runtime
+  LIBRARY DESTINATION ${Autoscoper_BIN_DIR} COMPONENT Runtime
+  ARCHIVE DESTINATION ${Autoscoper_LIB_DIR} COMPONENT Development
+)
 

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -61,5 +61,5 @@ target_include_directories(libautoscoper PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-install(TARGETS libautoscoper DESTINATION lib)
+install(TARGETS libautoscoper DESTINATION ${Autoscoper_LIB_DIR})
 


### PR DESCRIPTION
This commit is a follow-up of d076839 (COMP: Set target properties for
output paths)