### PR TITLE
Add Autoscoper_RENDERING_BACKEND option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,22 @@ endif()
 #-----------------------------------------------------------------------------
 # Options
 #-----------------------------------------------------------------------------
-option(Autoscoper_BUILD_WITH_CUDA "Build With CUDA instead of OpenCL" ON)
-mark_as_superbuild(Autoscoper_BUILD_WITH_CUDA)
+set(_default_backend "CUDA")
+set(_force_backend )
+if(DEFINED Autoscoper_BUILD_WITH_CUDA)
+  set(_force_backend FORCE)
+  if(NOT Autoscoper_BUILD_WITH_CUDA)
+    set(_default_backend "OpenCL")
+  endif()
+  message(DEPRECATION "Consider setting Autoscoper_RENDERING_BACKEND to '${_default_backend}' instead of Autoscoper_BUILD_WITH_CUDA to '${Autoscoper_BUILD_WITH_CUDA}'")
+endif()
+set(Autoscoper_RENDERING_BACKEND "${_default_backend}" CACHE STRING "Backend to use for DRR and radiograph rendering" ${_force_backend})
+set_property(CACHE Autoscoper_RENDERING_BACKEND PROPERTY STRINGS "CUDA" "OpenCL")
+if(NOT Autoscoper_RENDERING_BACKEND MATCHES "^(CUDA|OpenCL)$")
+  message(FATAL_ERROR "Autoscoper_RENDERING_BACKEND must be set to CUDA or OpenCL")
+endif()
+mark_as_superbuild(Autoscoper_RENDERING_BACKEND)
+message(STATUS "Configuring with rendering backend '${Autoscoper_RENDERING_BACKEND}'")
 
 option(Autoscoper_INSTALL_SAMPLE_DATA "Copy/Install the sample data to the build/install directory" ON)
 mark_as_superbuild(Autoscoper_INSTALL_SAMPLE_DATA)
@@ -79,7 +93,7 @@ endif()
 set(CMAKE_C_FLAGS_RELEASE "-O3")
 set(BUILD_SHARED_LIBS ON)
 
-if(Autoscoper_BUILD_WITH_CUDA)
+if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   add_definitions(-DWITH_CUDA)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if(NOT Autoscoper_RENDERING_BACKEND MATCHES "^(CUDA|OpenCL)$")
   message(FATAL_ERROR "Autoscoper_RENDERING_BACKEND must be set to CUDA or OpenCL")
 endif()
 mark_as_superbuild(Autoscoper_RENDERING_BACKEND)
+set(Autoscoper_RENDERING_USE_${Autoscoper_RENDERING_BACKEND}_BACKEND 1)
 message(STATUS "Configuring with rendering backend '${Autoscoper_RENDERING_BACKEND}'")
 
 option(Autoscoper_INSTALL_SAMPLE_DATA "Copy/Install the sample data to the build/install directory" ON)
@@ -92,10 +93,6 @@ endif()
 
 set(CMAKE_C_FLAGS_RELEASE "-O3")
 set(BUILD_SHARED_LIBS ON)
-
-if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
-  add_definitions(-DWITH_CUDA)
-endif()
 
 #-----------------------------------------------------------------------------
 # Dependencies

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -108,18 +108,20 @@ set_target_properties(autoscoper PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_LIB_DIR}"
 )
 
-if(Autoscoper_BUILD_WITH_CUDA)
+if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   find_package(CUDA REQUIRED)
   target_include_directories(autoscoper PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/cutil)
   set(GPU_LIBRARIES
     ${CUDA_LIBRARIES}
   )
-else()
+elseif(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   find_package(OpenCL REQUIRED)
   target_include_directories(autoscoper PUBLIC ${OPENCL_INCLUDE_DIRS})
   set(GPU_LIBRARIES
     ${OpenCL_LIBRARIES}
   )
+else()
+  message(FATAL_ERROR "Setting Autoscoper_RENDERING_BACKEND to '${Autoscoper_RENDERING_BACKEND}' is not supported")
 endif()
 
 target_link_libraries(autoscoper PUBLIC libautoscoper

--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -74,7 +74,7 @@
 #include <QShortcut>
 #include <QXmlStreamWriter>
 
-#ifndef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include <gpu/opencl/OpenCL.hpp>
 #endif
 
@@ -132,7 +132,7 @@ AutoscoperMainWindow::AutoscoperMainWindow(bool skipGpuDevice, QWidget *parent) 
   setLastFolder(QDir::currentPath());
 
 
-#ifndef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   if (!skipGpuDevice){
     OpenCLPlatformSelectDialog * dialog = new OpenCLPlatformSelectDialog(this);
     if (dialog->getNumberPlatforms() > 1)dialog->exec();
@@ -1471,7 +1471,7 @@ void AutoscoperMainWindow::on_actionSaveForBatch_triggered(bool checked){
         xmlWriter.writeStartElement("Batch");
         xmlWriter.setAutoFormatting(true);
         //save GPU_devices
-#ifndef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
         xmlWriter.writeStartElement("GPUDevice");
         xmlWriter.writeAttribute("Platform", QString::number(xromm::gpu::getUsedPlatform().first));
         xmlWriter.writeAttribute("Device", QString::number(xromm::gpu::getUsedPlatform().second));
@@ -1579,7 +1579,7 @@ void AutoscoperMainWindow::runBatch(QString batchfile, bool saveData){
             QString name = xmlReader.name().toString();
             if (name == "GPUDevice")
             {
-#ifndef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
               fprintf(stderr, "Load GPUDevice Setting\n");
               xromm::gpu::setUsedPlatform(xmlReader.readElementText().toInt());
               QApplication::processEvents();

--- a/autoscoper/src/ui/FilterTreeWidgetItem.cpp
+++ b/autoscoper/src/ui/FilterTreeWidgetItem.cpp
@@ -55,12 +55,12 @@
 #include <QGroupBox>
 #include <QCheckBox>
 
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 #include <gpu/cuda/SobelFilter.hpp>
 #include <gpu/cuda/ContrastFilter.hpp>
 #include <gpu/cuda/SharpenFilter.hpp>
 #include <gpu/cuda/GaussianFilter.hpp>
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include <gpu/opencl/SobelFilter.hpp>
 #include <gpu/opencl/ContrastFilter.hpp>
 #include <gpu/opencl/SharpenFilter.hpp>

--- a/autoscoper/src/ui/GLTracker.cpp
+++ b/autoscoper/src/ui/GLTracker.cpp
@@ -52,8 +52,7 @@
 //#include <QOpenGLContext>
 //#include <QOpenGLFunctions>
 
-#ifdef WITH_CUDA
-#else
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include <gpu/opencl/OpenCL.hpp>
 #endif
 
@@ -93,8 +92,7 @@ void GLTracker::initializeGL(){
     glClearColor(0.5,0.5,0.5,1.0);
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
-#ifdef WITH_CUDA
-#else
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   std::cerr << "Initializing OpenCL-OpenGL interoperability..." << std::endl;
   xromm::gpu::opencl_global_gl_context();
 #endif

--- a/autoscoper/src/ui/GLView.cpp
+++ b/autoscoper/src/ui/GLView.cpp
@@ -70,10 +70,10 @@
 #include "Manip3D.hpp"
 
 
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 #include <gpu/cuda/RadRenderer.hpp>
 #include <gpu/cuda/RayCaster.hpp>
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include <gpu/opencl/RadRenderer.hpp>
 #include <gpu/opencl/RayCaster.hpp>
 #endif
@@ -481,19 +481,19 @@ void GLView::paintGL()
 
         CALL_GL(glRasterPos2i(0, 0));
 
-  #ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
         CALL_GL(glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, viewdata.pbo));
         CALL_GL(glDrawPixels(viewdata.window_width,
                viewdata.window_height,
                GL_RGB, GL_FLOAT, 0));
         CALL_GL(glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, 0));
-  #else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
         CALL_GL(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, viewdata.pbo));
         CALL_GL(glDrawPixels(viewdata.window_width,
                viewdata.window_height,
                GL_RGB, GL_FLOAT, 0));
         CALL_GL(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0));
-  #endif
+#endif
         CALL_GL(glDisable(GL_BLEND));
         CALL_GL(glEnable(GL_DEPTH_TEST));
       }
@@ -538,19 +538,19 @@ void GLView::paintGL()
       glDisable(GL_DEPTH_TEST);
       glRasterPos2i(0, 0);
 
-      #ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
       CALL_GL(glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, viewdata.pbo));
       CALL_GL(glDrawPixels(viewdata.window_width,
               viewdata.window_height,
               GL_RGB, GL_FLOAT, 0));
       CALL_GL(glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, 0));
-      #else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
       CALL_GL(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, viewdata.pbo));
       CALL_GL(glDrawPixels(viewdata.window_width,
               viewdata.window_height,
               GL_RGB, GL_FLOAT, 0));
       CALL_GL(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0));
-      #endif
+#endif
 
       glEnable(GL_DEPTH_TEST);
 

--- a/autoscoper/src/ui/GLWidget.cpp
+++ b/autoscoper/src/ui/GLWidget.cpp
@@ -96,7 +96,7 @@ void GLWidget::resizeGL(int w, int h){
 
     viewdata.ratio = (float)viewdata.window_width/(float)viewdata.window_height;
 
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
   // Unregister and delete the pixel buffer if it already exists.
     if (!glIsBufferARB(viewdata.pbo)) {
         CALL_GL(glDeleteBuffersARB(1, &viewdata.pbo));
@@ -110,7 +110,7 @@ void GLWidget::resizeGL(int w, int h){
                 0,
                 GL_STREAM_DRAW_ARB));
     CALL_GL(glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, 0));
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   // Unregister and delete the pixel buffer if it already exists.
   if (!glIsBuffer(viewdata.pbo)) {
         CALL_GL(glDeleteBuffers(1, &viewdata.pbo));

--- a/autoscoper/src/ui/ModelViewTreeWidgetItem.cpp
+++ b/autoscoper/src/ui/ModelViewTreeWidgetItem.cpp
@@ -63,9 +63,9 @@
 #include <math.h>       /* exp */
 
 #include <View.hpp>
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 #include <gpu/cuda/RayCaster.hpp>
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include <gpu/opencl/RayCaster.hpp>
 #endif
 

--- a/autoscoper/src/ui/OpenCLPlatformSelectDialog.cpp
+++ b/autoscoper/src/ui/OpenCLPlatformSelectDialog.cpp
@@ -42,7 +42,7 @@
 #include "ui/OpenCLPlatformSelectDialog.h"
 #include "ui_OpenCLPlatformSelectDialog.h"
 
-#ifndef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include <gpu/opencl/OpenCL.hpp>
 #endif
 
@@ -54,7 +54,7 @@ OpenCLPlatformSelectDialog::OpenCLPlatformSelectDialog(QWidget *parent) :
 
   diag->setupUi(this);
 
-#ifndef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   platforms = xromm::gpu::get_platforms();
   for (int i = 0 ; i < platforms.size();i++){
     diag->comboBox->addItem(QString::fromStdString(platforms[i][0]));
@@ -77,7 +77,7 @@ void OpenCLPlatformSelectDialog::on_comboBox_currentIndexChanged ( int index ){
 }
 
 void OpenCLPlatformSelectDialog::on_pushButton_clicked(){
-#ifndef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   xromm::gpu::setUsedPlatform(diag->comboBox->currentIndex());
 #endif
   this->close();

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -48,6 +48,10 @@ else()
   message(FATAL_ERROR "Setting Autoscoper_RENDERING_BACKEND to '${Autoscoper_RENDERING_BACKEND}' is not supported")
 endif()
 
+target_compile_definitions(libautoscoper PUBLIC
+  Autoscoper_RENDERING_USE_${Autoscoper_RENDERING_BACKEND}_BACKEND
+)
+
 set_target_properties(libautoscoper PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_BIN_DIR}"
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_BIN_DIR}"

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -32,18 +32,20 @@ set(libautoscoper_SOURCES
   src/VolumeTransform.cpp
 )
 
-if(Autoscoper_BUILD_WITH_CUDA)
+if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   find_package(CUDA REQUIRED)
   set(CUDA_LIBRARIES PUBLIC ${CUDA_LIBRARIES})
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/CMakeLists.txt)
   CUDA_ADD_LIBRARY(libautoscoper STATIC ${libautoscoper_SOURCES} ${libautoscoper_HEADERS} ${cuda_HEADERS} ${cuda_SOURCES} ${cuda_KERNEL_HEADERS} ${cuda_KERNEL})
   target_include_directories(libautoscoper PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/cutil)
-else()
+elseif(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   find_package(OpenCL REQUIRED)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/opencl/CMakeLists.txt)
   add_library(libautoscoper STATIC ${libautoscoper_SOURCES} ${libautoscoper_HEADERS} ${opencl_SOURCES} ${opencl_HEADERS})
   target_include_directories(libautoscoper PUBLIC  ${OpenCL_INCLUDE_DIRS})
   add_dependencies(libautoscoper ${SHADER_TO_HEADER})
+else()
+  message(FATAL_ERROR "Setting Autoscoper_RENDERING_BACKEND to '${Autoscoper_RENDERING_BACKEND}' is not supported")
 endif()
 
 set_target_properties(libautoscoper PROPERTIES

--- a/libautoscoper/src/Filter.hpp
+++ b/libautoscoper/src/Filter.hpp
@@ -44,9 +44,9 @@
 
 #include <string>
 
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 typedef float Buffer;
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include "gpu/opencl/OpenCL.hpp"
 #endif
 

--- a/libautoscoper/src/Tracker.hpp
+++ b/libautoscoper/src/Tracker.hpp
@@ -47,17 +47,17 @@
 
 #include "Filter.hpp"
 
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 #include "gpu/cuda/RayCaster.hpp"
 #include "gpu/cuda/RadRenderer.hpp"
 #include "gpu/cuda/BackgroundRenderer.hpp"
-
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include "gpu/opencl/RayCaster.hpp"
 #include "gpu/opencl/RadRenderer.hpp"
 #include "gpu/opencl/BackgroundRenderer.hpp"
 #include "gpu/opencl/OpenCL.hpp"
 #endif
+
 #include "Trial.hpp"
 
 
@@ -111,12 +111,12 @@ namespace xromm
     Trial trial_;
     std::vector <gpu::VolumeDescription*> volumeDescription_;
     std::vector <gpu::View*> views_;
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
     Buffer* rendered_drr_;
     Buffer* rendered_rad_;
     Buffer* background_mask_;
     Buffer* drr_mask_;
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
     gpu::Buffer* rendered_drr_;
     gpu::Buffer* rendered_rad_;
     gpu::Buffer* background_mask_;

--- a/libautoscoper/src/View.hpp
+++ b/libautoscoper/src/View.hpp
@@ -44,10 +44,10 @@
 
 #include <vector>
 #include <string>
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 typedef float Buffer;
 typedef float GLBuffer;
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include "gpu/opencl/OpenCL.hpp"
 #endif
 
@@ -122,9 +122,9 @@ public:
   }
 
 private:
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
   void init();
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   void init(unsigned width, unsigned height);
 #endif
 

--- a/libautoscoper/src/VolumeDescription.cpp
+++ b/libautoscoper/src/VolumeDescription.cpp
@@ -46,7 +46,7 @@
 #include <fstream>
 #include <vector>
 
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 #include <cuda.h>
 #include <cutil_inline.h>
 #include <cutil_math.h>
@@ -279,7 +279,7 @@ VolumeDescription::VolumeDescription(const Volume& volume)
     invTrans_[2] = min[2]/(float)dim[2];
     // Free any previously allocated memory.
 
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
   // Free any previously allocated memory.
     cutilSafeCall(cudaFreeArray(image_));
 
@@ -305,7 +305,7 @@ VolumeDescription::VolumeDescription(const Volume& volume)
     copyParams.extent = extent;
     copyParams.kind = cudaMemcpyHostToDevice;
     cutilSafeCall(cudaMemcpy3D(&copyParams));
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   if (image_) delete image_;
 
     // Create a 3D array.
@@ -328,9 +328,9 @@ VolumeDescription::VolumeDescription(const Volume& volume)
 
 VolumeDescription::~VolumeDescription()
 {
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
   cutilSafeCall(cudaFreeArray(image_));
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   if (image_) delete image_;
 #endif
 }

--- a/libautoscoper/src/VolumeDescription.hpp
+++ b/libautoscoper/src/VolumeDescription.hpp
@@ -42,10 +42,10 @@
 #ifndef XROMM_GPU_VOLUME_DESCRIPTION_HPP
 #define XROMM_GPU_VOLUME_DESCRIPTION_HPP
 
-#ifdef WITH_CUDA
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 struct cudaArray;
 typedef cudaArray Image;
-#else
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #include "gpu/opencl/OpenCL.hpp"
 #endif
 


### PR DESCRIPTION
Deprecates the use of `Autoscoper_BUILD_WITH_CUDA` CMake option in favor of `Autoscoper_RENDERING_BACKEND` option accepting values like `CUDA` or `OpenCL`