### PR TITLE
Fix OpenCL crashing on change trial

### DIFF
--- a/libautoscoper/src/View.cpp
+++ b/libautoscoper/src/View.cpp
@@ -128,7 +128,6 @@ View::~View()
   }
   delete drrBufferMerged_;
   delete drrFilterBuffer_;
-    delete drrFilterBuffer_;
     delete radBuffer_;
     delete radFilterBuffer_;
 


### PR DESCRIPTION
* Remove second instance of deletion of the drrFilterBuffer Object from view.cpp
* For reference, the deletion of drrFilterBuffer_ was first introduced in https://github.com/BrownBiomechanics/Autoscoper/commit/6b7ad8e6b7d808f1aa117dfc863d2ecdb00a0586 (initial commit), then the duplicated deletion was later introduced through https://github.com/BrownBiomechanics/Autoscoper/commit/0a58d670e95e8e010dc1990ff22430a346d1c287 (Multibone initial : manual port of https://github.com/BrownBiomechanics/Autoscoper/commit/31ed16ca4064c98e71eaf703dbc4d00e48cc31db)