### PR TITLE
Refactor OpenCL integration using maintained OpenCL C++ interface

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -3,6 +3,12 @@ set(Autoscoper_DEPENDENCIES
   GLEW
   TIFF
   )
+if(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
+  list(APPEND Autoscoper_DEPENDENCIES
+    OpenCL-CLHPP
+    OpenCL-ICD-Loader
+    )
+endif()
 
 set(proj ${SUPERBUILD_TOPLEVEL_PROJECT})
 

--- a/Superbuild/External_OpenCL-CLHPP.cmake
+++ b/Superbuild/External_OpenCL-CLHPP.cmake
@@ -1,0 +1,68 @@
+
+set(proj OpenCL-CLHPP)
+
+set(${proj}_DEPENDENCIES "OpenCL-Headers")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(Autoscoper_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling Autoscoper_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED OpenCLHeadersCpp_DIR AND NOT EXISTS ${OpenCLHeadersCpp_DIR})
+  message(FATAL_ERROR "OpenCLHeadersCpp_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED OpenCLHeadersCpp_DIR AND NOT Autoscoper_USE_SYSTEM_${proj})
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  if(NOT CMAKE_CONFIGURATION_TYPES)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      )
+  endif()
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP.git
+    GIT_TAG v2022.09.30
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CMAKE_CACHE_ARGS
+      # Compiler settings
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
+      -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
+      -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
+      # Options
+      -DBUILD_DOCS:BOOL=OFF
+      -DBUILD_EXAMPLES:BOOL=OFF
+      -DBUILD_TESTING:BOOL=OFF
+      -DOPENCL_CLHPP_BUILD_TESTING:BOOL=OFF
+      # Install directories
+      -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+      # Dependencies
+      -DOpenCLHeaders_DIR:PATH=${OpenCLHeaders_DIR}
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+  set(OpenCLHeadersCpp_DIR ${EP_BINARY_DIR}/OpenCLHeadersCpp)
+
+endif()
+
+mark_as_superbuild(
+  VARS
+    OpenCLHeadersCpp_DIR:PATH
+  )
+
+ExternalProject_Message(${proj} "OpenCLHeadersCpp_DIR:${OpenCLHeadersCpp_DIR}")

--- a/Superbuild/External_OpenCL-Headers.cmake
+++ b/Superbuild/External_OpenCL-Headers.cmake
@@ -1,0 +1,60 @@
+
+set(proj OpenCL-Headers)
+
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(Autoscoper_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling Autoscoper_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED OpenCLHeaders_DIR AND NOT EXISTS ${OpenCLHeaders_DIR})
+  message(FATAL_ERROR "OpenCLHeaders_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED OpenCLHeaders_DIR AND NOT Autoscoper_USE_SYSTEM_${proj})
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  if(NOT CMAKE_CONFIGURATION_TYPES)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      )
+  endif()
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers.git
+    GIT_TAG v2022.09.30
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CMAKE_CACHE_ARGS
+      # Compiler settings
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      # Options
+      -DBUILD_TESTING:BOOL=OFF
+      -DOPENCL_HEADERS_BUILD_TESTING:BOOL=OFF
+      # Install directories
+      -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+  set(OpenCLHeaders_DIR ${EP_BINARY_DIR}/OpenCLHeaders)
+
+endif()
+
+mark_as_superbuild(
+  VARS
+    OpenCLHeaders_DIR:PATH
+  )
+
+ExternalProject_Message(${proj} "OpenCLHeaders_DIR:${OpenCLHeaders_DIR}")

--- a/Superbuild/External_OpenCL-ICD-Loader.cmake
+++ b/Superbuild/External_OpenCL-ICD-Loader.cmake
@@ -1,0 +1,64 @@
+
+set(proj OpenCL-ICD-Loader)
+
+set(${proj}_DEPENDENCIES
+  OpenCL-Headers
+  )
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(Autoscoper_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling Autoscoper_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED OpenCLICDLoader_DIR AND NOT EXISTS ${OpenCLICDLoader_DIR})
+  message(FATAL_ERROR "OpenCLICDLoader_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED OpenCLICDLoader_DIR AND NOT Autoscoper_USE_SYSTEM_${proj})
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  if(NOT CMAKE_CONFIGURATION_TYPES)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      )
+  endif()
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
+    GIT_TAG v2022.09.30
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CMAKE_CACHE_ARGS
+      # Compiler settings
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      # Options
+      -DBUILD_TESTING:BOOL=OFF
+      -DOPENCL_ICD_LOADER_BUILD_TESTING:BOOL=OFF
+      # Install directories
+      -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+      # Depdendencies
+      -DOpenCLHeaders_DIR:PATH=${OpenCLHeaders_DIR}
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+  set(OpenCLICDLoader_DIR ${EP_BINARY_DIR}/OpenCLHeaders)
+
+endif()
+
+mark_as_superbuild(
+  VARS
+    OpenCLICDLoader_DIR:PATH
+  )
+
+ExternalProject_Message(${proj} "OpenCLICDLoader_DIR:${OpenCLICDLoader_DIR}")

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -116,11 +116,19 @@ if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   )
 elseif(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   find_package(OpenCL ${Autoscoper_OpenCL_MINIMUM_REQUIRED_VERSION} REQUIRED)
-  target_include_directories(autoscoper PUBLIC ${OPENCL_INCLUDE_DIRS})
+  find_package(OpenCLHeaders REQUIRED)
+  find_package(OpenCLHeadersCpp REQUIRED)
+  #target_include_directories(autoscoper PUBLIC ${OPENCL_INCLUDE_DIRS})
   set(GPU_LIBRARIES
     ${OpenCL_LIBRARIES}
+    OpenCL::HeadersCpp
   )
-  target_compile_definitions(autoscoper PRIVATE CL_TARGET_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION})
+  target_compile_definitions(autoscoper PRIVATE
+    CL_TARGET_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION}
+    CL_HPP_TARGET_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION}
+    CL_HPP_MINIMUM_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION}
+    CL_HPP_ENABLE_EXCEPTIONS
+  )
 else()
   message(FATAL_ERROR "Setting Autoscoper_RENDERING_BACKEND to '${Autoscoper_RENDERING_BACKEND}' is not supported")
 endif()

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -40,11 +40,21 @@ if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   target_include_directories(libautoscoper PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/cutil)
 elseif(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   find_package(OpenCL ${Autoscoper_OpenCL_MINIMUM_REQUIRED_VERSION} REQUIRED)
+  find_package(OpenCLHeaders REQUIRED)
+  find_package(OpenCLHeadersCpp REQUIRED)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/opencl/CMakeLists.txt)
   add_library(libautoscoper STATIC ${libautoscoper_SOURCES} ${libautoscoper_HEADERS} ${opencl_SOURCES} ${opencl_HEADERS})
-  target_include_directories(libautoscoper PUBLIC  ${OpenCL_INCLUDE_DIRS})
+  #target_include_directories(libautoscoper PUBLIC  ${OpenCL_INCLUDE_DIRS})
   add_dependencies(libautoscoper ${SHADER_TO_HEADER})
-  target_compile_definitions(libautoscoper PRIVATE CL_TARGET_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION})
+  target_link_libraries(libautoscoper PUBLIC
+    OpenCL::HeadersCpp
+  )
+  target_compile_definitions(libautoscoper PRIVATE
+    CL_TARGET_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION}
+    CL_HPP_TARGET_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION}
+    CL_HPP_MINIMUM_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION}
+    CL_HPP_ENABLE_EXCEPTIONS
+  )
 else()
   message(FATAL_ERROR "Setting Autoscoper_RENDERING_BACKEND to '${Autoscoper_RENDERING_BACKEND}' is not supported")
 endif()

--- a/libautoscoper/src/gpu/opencl/OpenCL.cpp
+++ b/libautoscoper/src/gpu/opencl/OpenCL.cpp
@@ -994,7 +994,7 @@ void Buffer::fill(const float val) const
 #endif
 }
 
-GLBuffer::GLBuffer(GLuint pbo, cl_mem_flags access)
+GLBuffer::GLBuffer(cl_GLuint pbo, cl_mem_flags access)
 {
   err_ = opencl_global_context();
   CHECK_CL

--- a/libautoscoper/src/gpu/opencl/OpenCL.cpp
+++ b/libautoscoper/src/gpu/opencl/OpenCL.cpp
@@ -178,6 +178,14 @@ static const char* opencl_error(cl_int err)
     case CL_INVALID_LINKER_OPTIONS: return "CL_INVALID_LINKER_OPTIONS";
     case CL_INVALID_DEVICE_PARTITION_COUNT: return "CL_INVALID_DEVICE_PARTITION_COUNT";
 #endif
+#ifdef CL_VERSION_2_0
+    case CL_INVALID_PIPE_SIZE: return "CL_INVALID_PIPE_SIZE";
+    case CL_INVALID_DEVICE_QUEUE: return "CL_INVALID_DEVICE_QUEUE";
+#endif
+#ifdef CL_VERSION_2_2
+    case CL_INVALID_SPEC_ID: return "CL_INVALID_SPEC_ID";
+    case CL_MAX_SIZE_RESTRICTION_EXCEEDED: return "CL_MAX_SIZE_RESTRICTION_EXCEEDED";
+#endif
     default: return "Unknown";
     }
 }

--- a/libautoscoper/src/gpu/opencl/OpenCL.hpp
+++ b/libautoscoper/src/gpu/opencl/OpenCL.hpp
@@ -42,19 +42,10 @@
 #ifndef XROMM_HPP
 #define XROMM_HPP
 
+#include <CL/opencl.hpp>
+
 #include <iostream>
 #include <vector>
-
-#if defined(__APPLE__) || defined(__MACOSX)
-#include <OpenCL/opencl.h>
-#include <OpenGL/OpenGL.h>
-#else
-#if defined(_WIN32)
-#include <windows.h>
-#endif
-#include <CL/opencl.h>
-#include <GL/gl.h>
-#endif
 
 namespace xromm { namespace gpu {
 

--- a/libautoscoper/src/gpu/opencl/OpenCL.hpp
+++ b/libautoscoper/src/gpu/opencl/OpenCL.hpp
@@ -65,7 +65,7 @@ class Image;
 class Kernel
 {
 public:
-  Kernel(cl_program program, const char* func);
+  Kernel(const cl::Program& program, const char* func);
   void reset();
 
   static size_t getLocalMemSize();
@@ -105,7 +105,7 @@ public:
   Program();
     Kernel* compile(const char* code, const char* func);
 protected:
-  cl_program program_;
+  cl::Program program_;
   bool compiled_;
 };
 

--- a/libautoscoper/src/gpu/opencl/OpenCL.hpp
+++ b/libautoscoper/src/gpu/opencl/OpenCL.hpp
@@ -140,7 +140,7 @@ protected:
 class GLBuffer
 {
 public:
-  GLBuffer(GLuint pbo, cl_mem_flags access=CL_MEM_READ_WRITE);
+  GLBuffer(cl_GLuint pbo, cl_mem_flags access=CL_MEM_READ_WRITE);
   ~GLBuffer();
   friend class Kernel;
 protected:


### PR DESCRIPTION
* Add OpenCL-(CLHPP|Headers|ICD-Loader} external projects
* Refactor Autoscoper OpenCL classes to use `cl::*` object

References
* https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend
* [Commit](https://github.com/BrownBiomechanics/Autoscoper/compare/7ddf514b037f0a0bed912e3b342e5f7b2794abc8...jcfr:integrate-OpenCL-Headers-CLHPP-ICD-Loader_disabled-opencl-except-sobel) for disabling all OpenCL code paths except the Sobel filter.

Notes:
* on macOS, we will likely have to integrate [OpenCL-SDK](https://github.com/KhronosGroup/OpenCL-SDK) likely because (?) the system OpenCL header available on macOS only support an older OpenCL version.