### PR TITLE
Add option to specify seed for random number generation

### DIFF
--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -5,6 +5,7 @@ set(libautoscoper_HEADERS
   src/DownhillSimplex.hpp
   src/Filter.hpp
   src/KeyCurve.hpp
+  src/PSO.hpp
   src/TiffImage.h
   src/Tracker.hpp
   src/Trial.hpp
@@ -20,7 +21,7 @@ set(libautoscoper_SOURCES
   src/Camera.cpp
   src/CoordFrame.cpp
   src/DownhillSimplex.cpp
-  src/PSO_kernel.cpp
+  src/PSO.cpp
   src/KeyCurve.cpp
   src/TiffImage.cpp
   src/Tracker.cpp

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -1,5 +1,6 @@
 #include "PSO.hpp"
 #include <iostream>
+#include <string>
 
 
 // New Particle Swarm Optimization
@@ -14,6 +15,25 @@ float host_fitness_function(float x[])
   double total = PSO_FUNC(xyzypr_manip);
 
   return (float)total;
+}
+
+void intializeRandom()
+{
+  if (char* randomSeed = std::getenv("Autoscoper_RANDOM_SEED")) {
+    try {
+      std::cout << "Setting to Autoscoper_RANDOM_SEED to " << randomSeed << std::endl;
+      unsigned int seed = std::stoi(std::string(randomSeed));
+      srand(seed);
+    }
+    catch (const std::invalid_argument &e) {
+      std::cerr << "Autoscoper_RANDOM_SEED is not a valid integer" << std::endl;
+      exit(1);
+    }
+    catch (const std::out_of_range &e) {
+      std::cerr << "Autoscoper_RANDOM_SEED is out of range" << std::endl;
+      exit(1);
+    }
+  }
 }
 
 float getRandom(float low, float high)

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -1,4 +1,4 @@
-#include "gpu/cuda/PSO_kernel.h"
+#include "PSO.hpp"
 #include <iostream>
 
 

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -1,0 +1,27 @@
+/*
+ * pso_kernel.h
+ *
+ *  Created on: Jul 27, 2017
+ *      Author: root
+ */
+
+#pragma once
+
+ // ADD: NEW PSO
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <math.h>
+const int NUM_OF_PARTICLES = 100;
+const int NUM_OF_DIMENSIONS = 6;
+const float c1 = 1.5f;
+const float c2 = 1.5f;
+// END: NEW PSO
+
+double PSO_FUNC(double *P);
+
+float getRandom(float low, float high);
+float getRandomClamped();
+float host_fitness_function(float x[]);
+
+void pso(float *positions, float *velocities, float *pBests, float *gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -20,6 +20,8 @@ const float c2 = 1.5f;
 
 double PSO_FUNC(double *P);
 
+void intializeRandom();
+
 float getRandom(float low, float high);
 float getRandomClamped();
 float host_fitness_function(float x[]);

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -210,6 +210,7 @@ Tracker::Tracker()
     g_markerless = this;
   optimization_method = 0; // initialize cost function
   cf_model_select = 0; //cost function selector
+  intializeRandom();
 }
 
 Tracker::~Tracker()

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -310,6 +310,7 @@ void Tracker::load(const Trial& trial)
 
 void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsigned int max_iter, double min_limit, double max_limit, int cf_model, unsigned int max_stall_iter)
 {
+  intializeRandom();
 
   optimization_method = opt_method;
   cf_model_select = cf_model;

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -59,12 +59,10 @@
   #include "gpu/cuda/HDist_kernels.h"
   #include "gpu/cuda/Compositor_kernels.h"
   #include "gpu/cuda/Mult_kernels.h"
-  #include "gpu/cuda/PSO_kernel.h"
   #include <cuda_runtime_api.h>
 #elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   #include "gpu/opencl/Ncc.hpp"
   #include "gpu/opencl/Mult.hpp"
-  #include "gpu/cuda/PSO_kernel.h"
 #endif
 
 #include "VolumeDescription.hpp"
@@ -74,6 +72,7 @@
 #include "SimulatedAnnealing.hpp"
 #include "Camera.hpp"
 #include "CoordFrame.hpp"
+#include "PSO.hpp"
 
 
 using namespace std;

--- a/libautoscoper/src/gpu/cuda/PSO_kernel.h
+++ b/libautoscoper/src/gpu/cuda/PSO_kernel.h
@@ -7,24 +7,12 @@
 
 #pragma once
 
- // ADD: NEW PSO
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
-#include <math.h>
-const int NUM_OF_PARTICLES = 100;
-const int NUM_OF_DIMENSIONS = 6;
-const float c1 = 1.5f;
-const float c2 = 1.5f;
-// END: NEW PSO
+namespace xromm {
 
-double PSO_FUNC(double *P);
-
-float getRandom(float low, float high);
-float getRandomClamped();
-float host_fitness_function(float x[]);
-
-void pso(float *positions, float *velocities, float *pBests, float *gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);
-
+namespace gpu {
 
 // extern "C" void cuda_pso(float *positions, float *velocities, float *pBests, float *gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);
+
+} // namespace gpu
+
+} // namespace xromm


### PR DESCRIPTION
* When the environment variable `Autoscoper_RANDOM_SEED` is set, it will be used for the random number generation in the PSO kernel. 