### PR TITLE
COMP: Fix libautoscoper linking against CUDA libraries

### DIFF
--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -35,9 +35,12 @@ set(libautoscoper_SOURCES
 if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   find_package(CUDA REQUIRED)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/CMakeLists.txt)
+  # Ensure calls to "target_link_libraries()" used in "CUDA_ADD_LIBRARY()" also
+  # specify a scope keyword.
+  set(CUDA_LINK_LIBRARIES_KEYWORD "PUBLIC")
   CUDA_ADD_LIBRARY(libautoscoper STATIC ${libautoscoper_SOURCES} ${libautoscoper_HEADERS} ${cuda_HEADERS} ${cuda_SOURCES} ${cuda_KERNEL_HEADERS} ${cuda_KERNEL})
   target_include_directories(libautoscoper PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/cutil)
-  target_link_libraries(libautoscoper PUBLIC ${CUDA_LIBRARIES})
+  # Explicitly linking against CUDA_LIBRARIES is already done in "CUDA_ADD_LIBRARY()".
 elseif(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   find_package(OpenCL ${Autoscoper_OpenCL_MINIMUM_REQUIRED_VERSION} REQUIRED)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/opencl/CMakeLists.txt)


### PR DESCRIPTION
This commit fixes a regression introduced in 2adc328 (COMP: Simplify integration of GPU libraries leveraging transitive usage) that caused the configure error reported below when doing a "clean" build with the CUDA backend enabled.

The option `CUDA_LINK_LIBRARIES_KEYWORD` introduced in CMake 3.9 is now set to explicitly ensure a scope keyword is used in `CUDA_ADD_LIBRARY()`.

Configuration error:

```
-- Found CUDA: /usr/local/cuda (found version "10.2")
CMake Error at libautoscoper/CMakeLists.txt:43 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "libautoscoper".  All uses of target_link_libraries with a
  target must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * /usr/local/cmake-3.24.3-linux-x86_64/share/cmake-3.24/Modules/FindCUDA.cmake:1996 (target_link_libraries)
```

This commit also removes the explicit linking to CUDA_LIBRARIES because it is already done in `CUDA_ADD_LIBRARY()` and keeping it would lead to the following linking error:

```
[ 47%] Linking CXX executable ../bin/autoscoper
/usr/bin/ld: /usr/local/cuda/lib64/libcudart_static.a(libcudart_static.a.o): undefined reference to symbol 'pthread_rwlock_trywrlock@@GLIBC_2.2.5'
/lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```

For future reference, here are the different GNU link commands:

| Before regression (4fe41ad) :heavy_check_mark:  <-> With regression (2adc328) :x:|
|---|
| ![image](https://user-images.githubusercontent.com/219043/208188568-433a9876-aa84-41e5-bd49-a206afb1a0ee.png) |



| Before regression (4fe41ad) :heavy_check_mark: <-> With regression fix (this PR) :heavy_check_mark:|
|---|
| ![image](https://user-images.githubusercontent.com/219043/208188655-8fc65800-8cbb-41b6-a80f-1ee141760501.png) |
