### PR TITLE
Stop socket from waiting after closing connection

### DIFF
--- a/scripts/python/PyAutoscoper/connect.py
+++ b/scripts/python/PyAutoscoper/connect.py
@@ -460,9 +460,6 @@ class AutoscoperConnection:
         # convert 13 to bytes
         b.append(0x0D)
         self.socket.sendall(b)
-        res = self.wait_for_server()
-        if int.from_bytes(res, byteorder="little", signed=False) != 0x0D:
-            raise Exception("Server Error closing connection")
         self.socket.close()
         self.is_connected = False
 


### PR DESCRIPTION
* fixed issue with `closeConnection` in PyAutoscoper where after the connection to the server was severed the socket would wait indefinitely for the server. 