### PR TITLE
Add support for retrieving # of volumes and frames over network

### DIFF
--- a/autoscoper/src/net/Socket.cpp
+++ b/autoscoper/src/net/Socket.cpp
@@ -307,7 +307,26 @@ void Socket::handleMessage(QTcpSocket * connection, char* data, qint64 length)
       connection->disconnectFromHost();
     }
     break;
-  
+
+  case 14:
+    // get number of volumes
+    {
+      int nvol = m_mainwindow->getNumVolumes();
+      QByteArray array = QByteArray(1, 14);
+      array.append((char*)&nvol, sizeof(int));
+      connection->write(array);
+    }
+    break;
+
+  case 15:
+    // get number of frames
+    {
+      int nframe = m_mainwindow->getNumFrames();
+      QByteArray array = QByteArray(1, 15);
+      array.append((char*)&nframe, sizeof(int));
+      connection->write(array);
+    }
+    break;
   default:
     std::cerr << "Cannot handle message" << std::endl;
     connection->write(QByteArray(1,0));

--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -2423,3 +2423,11 @@ void AutoscoperMainWindow::setupShortcuts(){
   ui->actionQuit->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
   ui->actionInsert_Key->setShortcut(QKeySequence(Qt::Key_S));
 }
+
+int AutoscoperMainWindow::getNumVolumes() {
+    return tracker->trial()->num_volumes;
+}
+
+int AutoscoperMainWindow::getNumFrames() {
+    return tracker->trial()->num_frames;
+}

--- a/autoscoper/src/ui/AutoscoperMainWindow.h
+++ b/autoscoper/src/ui/AutoscoperMainWindow.h
@@ -126,6 +126,8 @@ class AutoscoperMainWindow : public QMainWindow{
     void saveFullDRR();
     std::vector <unsigned char> getImageData(unsigned int volumeID, unsigned int camera, double* xyzpr, unsigned int &width, unsigned int &height);
     void optimizeFrame(int volumeID, int frame, int dframe, int repeats, int opt_method, unsigned int max_iter, double min_limit, double max_limit, int cf_model, unsigned int stall_iter);
+    int getNumVolumes();
+    int getNumFrames();
 
 
     // Backup Save
@@ -204,6 +206,7 @@ class AutoscoperMainWindow : public QMainWindow{
     double rand_gen_main(double fMin, double fMax);
 
     void load_tracking_results(QString filename);
+
     protected:
     void closeEvent(QCloseEvent *event);
   public slots:
@@ -287,7 +290,6 @@ class AutoscoperMainWindow : public QMainWindow{
     void key_plus_pressed();
     void key_equal_pressed();
     void key_minus_pressed();
-
 };
 
 #endif  // UAUTOSCOPERMAINWINDOW_H

--- a/scripts/python/PyAutoscoper/connect.py
+++ b/scripts/python/PyAutoscoper/connect.py
@@ -244,7 +244,6 @@ class AutoscoperConnection:
         b.extend(frame.to_bytes(4, byteorder="little", signed=False))
         self.socket.sendall(b)
         data = self._wait_for_server()
-        print(data[0])
         if data[0] != 0x06:
             self.closeConnection()
             raise Exception("Server Error getting pose")

--- a/scripts/python/PyAutoscoper/connect.py
+++ b/scripts/python/PyAutoscoper/connect.py
@@ -527,3 +527,39 @@ class AutoscoperConnection:
                 cf_model=cf_model,
                 dframe=frame_skip,
             )
+
+    def getNumVolumes(self):
+        """
+        Get the number of volumes in the scene.
+
+        :return: The number of volumes in the scene
+        :rtype: int
+        :raises Exception: If the server fails to get the number of volumes
+        """
+        b = bytearray()
+        # convert 14 to bytes
+        b.append(0x0E)
+        self.socket.sendall(b)
+        res = self._wait_for_server()
+        if res[0] != 0x0E:
+            self.closeConnection()
+            raise Exception("Server Error getting number of volumes")
+        return int.from_bytes(res[1:], byteorder="little", signed=False)
+
+    def getNumFrames(self):
+        """
+        Get the number of frames in the scene.
+
+        :return: The number of frames in the scene
+        :rtype: int
+        :raises Exception: If the server fails to get the number of frames
+        """
+        b = bytearray()
+        # convert 15 to bytes
+        b.append(0x0F)
+        self.socket.sendall(b)
+        res = self._wait_for_server()
+        if res[0] != 0x0F:
+            self.closeConnection()
+            raise Exception("Server Error getting number of frames")
+        return int.from_bytes(res[1:], byteorder="little", signed=False)


### PR DESCRIPTION
* Added ability to get the number of frames and number of volumes through the socket
* Updated PyAutoscoper to get frames and volumes
   * PyAutoscoper 1.1.1

------------------- 

## Updates

### Commit history associated with PyAutoscoper 1.1.1

PyAutoscoper 1.1.1 is associated with the tag [python-client-v1.1.1](https://github.com/BrownBiomechanics/Autoscoper/releases/tag/python-client-v1.1.1). Since it was created before this pull request was finalized, the code that will ultimately be integrated into the `main` branch will slightly be different.

### Fix related to "save tracking data" C++ implementation

The commit originally titled `BUG: Fix socket checking if file exists rather than path when saving data` that was initially associated with this pull request has been pushed into its pull request:
* https://github.com/BrownBiomechanics/Autoscoper/pull/93

