### PR TITLE
COMP: Support enabling/disabling installation of Qt libraries

### DIFF
--- a/CMake/AutoscoperInstallQt.cmake
+++ b/CMake/AutoscoperInstallQt.cmake
@@ -31,4 +31,6 @@ if(WIN32)
     DESTINATION ${Autoscoper_BIN_DIR}/Debug/platforms CONFIGURATIONS Debug
     COMPONENT Runtime
   )
+else()
+  message(AUTHOR_WARNING "Installing Qt libraries is only supported on Windows")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,13 @@ mark_as_superbuild(Autoscoper_RENDERING_BACKEND)
 set(Autoscoper_RENDERING_USE_${Autoscoper_RENDERING_BACKEND}_BACKEND 1)
 message(STATUS "Configuring with rendering backend '${Autoscoper_RENDERING_BACKEND}'")
 
+set(_default OFF)
+if(WIN32)
+  set(_default ON)
+endif()
+option(Autoscoper_INSTALL_Qt_LIBRARIES "Install Qt libraries" ${_default})
+mark_as_superbuild(Autoscoper_INSTALL_Qt_LIBRARIES)
+
 option(Autoscoper_INSTALL_SAMPLE_DATA "Copy/Install the sample data to the build/install directory" ON)
 mark_as_superbuild(Autoscoper_INSTALL_SAMPLE_DATA)
 

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -129,4 +129,7 @@ target_compile_definitions(autoscoper PUBLIC -DUSE_GLEW)
 
 install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug COMPONENT Runtime)
 install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release COMPONENT Runtime)
-include("${Autoscoper_SOURCE_DIR}/CMake/AutoscoperInstallQt.cmake")
+
+if(Autoscoper_INSTALL_Qt_LIBRARIES)
+  include("${Autoscoper_SOURCE_DIR}/CMake/AutoscoperInstallQt.cmake")
+endif()


### PR DESCRIPTION
This commit introduces the option `Autoscoper_INSTALL_Qt_LIBRARIES` initialized to `ON` on Windows and `OFF` on the other platform where installing Qt is not supported.

A warning is displayed if option is enabled on a platform where the installation is not support.