### PR TITLE
COMP: Simplify install tree

### DIFF
--- a/CMake/AutoscoperInstallQt.cmake
+++ b/CMake/AutoscoperInstallQt.cmake
@@ -6,7 +6,7 @@ if(WIN32)
       ${_qt5Core_install_prefix}/bin/Qt5Gui.dll
       ${_qt5Core_install_prefix}/bin/Qt5Core.dll
       ${_qt5Core_install_prefix}/bin/Qt5Network.dll
-    DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release
+    DESTINATION ${Autoscoper_BIN_DIR} CONFIGURATIONS Release
     COMPONENT Runtime
   )
   install(
@@ -16,19 +16,19 @@ if(WIN32)
       ${_qt5Core_install_prefix}/bin/Qt5Guid.dll
       ${_qt5Core_install_prefix}/bin/Qt5Cored.dll
       ${_qt5Core_install_prefix}/bin/Qt5Networkd.dll
-    DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug
+    DESTINATION ${Autoscoper_BIN_DIR} CONFIGURATIONS Debug
     COMPONENT Runtime
   )
   install(
     FILES
       ${_qt5Core_install_prefix}/plugins/platforms/qwindows.dll
-    DESTINATION ${Autoscoper_BIN_DIR}/Release/platforms CONFIGURATIONS Release
+    DESTINATION ${Autoscoper_BIN_DIR}/platforms CONFIGURATIONS Release
     COMPONENT Runtime
   )
   install(
     FILES
       ${_qt5Core_install_prefix}/plugins/platforms/qwindowsd.dll
-    DESTINATION ${Autoscoper_BIN_DIR}/Debug/platforms CONFIGURATIONS Debug
+    DESTINATION ${Autoscoper_BIN_DIR}/platforms CONFIGURATIONS Debug
     COMPONENT Runtime
   )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,5 +231,5 @@ if(Autoscoper_INSTALL_SAMPLE_DATA)
     )
 
   # Install sample_data
-  install(DIRECTORY sample_data DESTINATION "${Autoscoper_INSTALL_SAMPLE_DATA_DIR}/${_copy_subdir}" COMPONENT Runtime)
+  install(DIRECTORY sample_data DESTINATION "${Autoscoper_INSTALL_SAMPLE_DATA_DIR}" COMPONENT Runtime)
 endif()

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -127,8 +127,7 @@ find_package(GLEW REQUIRED CONFIG)
 target_link_libraries(autoscoper PUBLIC GLEW::GLEW)
 target_compile_definitions(autoscoper PUBLIC -DUSE_GLEW)
 
-install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Debug CONFIGURATIONS Debug COMPONENT Runtime)
-install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR}/Release CONFIGURATIONS Release COMPONENT Runtime)
+install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR} COMPONENT Runtime)
 
 if(Autoscoper_INSTALL_Qt_LIBRARIES)
   include("${Autoscoper_SOURCE_DIR}/CMake/AutoscoperInstallQt.cmake")


### PR DESCRIPTION
This commit simplifies the install tree (and by extension the packaged tree) by avoiding to have both Debug & Release artifacts copied.

Instead of installing both `Release` and `Debug` artifacts into the same tree, each configuration may be installed in completely different directory.

For example:

```
cmake --install C:\path\to\Autoscoper-build\Autoscoper-build ^
  --config Release ^
  --prefix C:\path\to\Autoscoper-install-Release
```