### PR TITLE
COMP: Initialize OpenGL_GL_PREFERENCE and pass if down to inner-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,16 @@ option(Autoscoper_SUPERBUILD "Build ${PROJECT_NAME} and the projects it depends 
 mark_as_advanced(Autoscoper_SUPERBUILD)
 set(Autoscoper_BINARY_INNER_SUBDIR Autoscoper-build)
 
+if(UNIX AND NOT APPLE)
+  if(NOT DEFINED OpenGL_GL_PREFERENCE)
+    set(OpenGL_GL_PREFERENCE "LEGACY")
+  endif()
+  if(NOT "${OpenGL_GL_PREFERENCE}" MATCHES "^(LEGACY|GLVND)$")
+    message(FATAL_ERROR "OpenGL_GL_PREFERENCE variable is expected to be set to LEGACY or GLVND")
+  endif()
+  mark_as_superbuild(OpenGL_GL_PREFERENCE:STRING)
+  message(STATUS "Setting OpenGL_GL_PREFERENCE to ${OpenGL_GL_PREFERENCE}")
+endif()
 
 if(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   set(Autoscoper_OpenCL_MINIMUM_REQUIRED_VERSION "1.2.0")


### PR DESCRIPTION
This commit addresses a warning like the following reported when building on Linux:

```
CMake Warning (dev) at /usr/share/cmake-3.22/Modules/FindOpenGL.cmake:315 (message):
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  FindOpenGL found both a legacy GL library:

    OPENGL_gl_LIBRARY: /usr/lib64/libGL.so

  and GLVND libraries for OpenGL and GLX:

    OPENGL_opengl_LIBRARY: /usr/lib64/libOpenGL.so
    OPENGL_glx_LIBRARY: /usr/lib64/libGLX.so

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
  compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
  autoscoper/CMakeLists.txt:1 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```