### PR TITLE
BUG: Fix trailing comma when saving single volume tracking data

### DIFF
--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -856,7 +856,7 @@ void AutoscoperMainWindow::save_tracking_results(QString filename, bool save_as_
         }
       }
 
-      if (j != tracker->trial()->num_volumes - 1) file << s;
+      if (j != stop - 1) file << s;
     }
     file << std::endl;
   }


### PR DESCRIPTION
* Fixes a small bug that adds a trailing comma when saving the tracking data from a single volume that is not the last volume. 
* Before for a volume that is not the last one (bottom of the volume selector)
```
X_data, Y_data, Z_data, YAW_data, PITCH_data, ROLL_data,
```
* After
```
X_data, Y_data, Z_data, YAW_data, PITCH_data, ROLL_data
```
* This bug was causing errors when the tracking data was read by other programs (particularly the numpy csv reader).