### PR TITLE
Disable sample data menus if sample data is not installed

### DIFF
--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -136,6 +136,8 @@ find_package(GLEW REQUIRED CONFIG)
 target_link_libraries(autoscoper PUBLIC GLEW::GLEW)
 target_compile_definitions(autoscoper PUBLIC -DUSE_GLEW)
 
+target_compile_definitions(autoscoper PRIVATE $<$<BOOL:${Autoscoper_INSTALL_SAMPLE_DATA}>:Autoscoper_INSTALL_SAMPLE_DATA>)
+
 install(TARGETS autoscoper DESTINATION ${Autoscoper_BIN_DIR} COMPONENT Runtime)
 
 if(Autoscoper_INSTALL_Qt_LIBRARIES)

--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -158,6 +158,13 @@ AutoscoperMainWindow::AutoscoperMainWindow(bool skipGpuDevice, QWidget *parent) 
 
   // Setup Shortcuts
   setupShortcuts();
+
+  // Enable the sample data menus if the sample data is installed
+#if defined(Autoscoper_INSTALL_SAMPLE_DATA)
+  ui->actionOpen_Sample_Wrist->setEnabled(true);
+  ui->actionOpen_Sample_Knee->setEnabled(true);
+  ui->actionOpen_Sample_Ankle->setEnabled(true);
+#endif 
 }
 
 AutoscoperMainWindow::~AutoscoperMainWindow(){

--- a/autoscoper/src/ui/ui-files/AutoscoperMainWindow.ui
+++ b/autoscoper/src/ui/ui-files/AutoscoperMainWindow.ui
@@ -411,7 +411,7 @@ Dialog</string>
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -661,21 +661,33 @@ Dialog</string>
    </property>
   </action>
   <action name="actionOpen_Sample_Wrist">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Open Sample - Wrist</string>
    </property>
   </action>
   <action name="actionAboutAutoscoper">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>About</string>
    </property>
   </action>
   <action name="actionOpen_Sample_Knee">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Open Sample - Knee</string>
    </property>
   </action>
   <action name="actionOpen_Sample_Ankle">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Open Sample - Ankle</string>
    </property>


### PR DESCRIPTION
* If the configuration option `Autoscoper_INSTALL_SAMPLE_DATA` is set to `OFF` then the sample data menus in the `Help` menu with be disabled
* Closing #121 in favor of this PR

![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/22579403-b655-4ec2-ac94-ad2a88e33338)

Related:
* https://github.com/BrownBiomechanics/Autoscoper/pull/121#pullrequestreview-1418594837
* https://github.com/BrownBiomechanics/Autoscoper/pull/29
