### PR TITLE
Restore support for building Autoscoper on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,11 @@ if(APPLE)
   mark_as_superbuild(Autoscoper_MACOSX_BUNDLE:BOOL)
 endif()
 
+if(NOT DEFINED Autoscoper_EXECUTABLE_LINK_FLAGS)
+  set(Autoscoper_EXECUTABLE_LINK_FLAGS "")
+endif()
+mark_as_superbuild(Autoscoper_EXECUTABLE_LINK_FLAGS:STRING)
+
 #-----------------------------------------------------------------------------
 # Dependencies
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,17 @@ endif()
 if(NOT DEFINED Autoscoper_BIN_DIR)
   set(Autoscoper_BIN_DIR bin)
 endif()
+mark_as_superbuild(Autoscoper_BIN_DIR:STRING)
+
 if(NOT DEFINED Autoscoper_LIB_DIR)
   set(Autoscoper_LIB_DIR lib)
 endif()
+mark_as_superbuild(Autoscoper_LIB_DIR:STRING)
+
 if(NOT DEFINED Autoscoper_SAMPLE_DATA_DIR)
   set(Autoscoper_SAMPLE_DATA_DIR "${Autoscoper_BIN_DIR}")
 endif()
+mark_as_superbuild(Autoscoper_SAMPLE_DATA_DIR:STRING)
 
 #-----------------------------------------------------------------------------
 # Options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,12 +121,20 @@ else()
   mark_as_superbuild(VARS CMAKE_CONFIGURATION_TYPES ALL_PROJECTS)
 endif()
 
+#-----------------------------------------------------------------------------
 if(NOT CMAKE_DEBUG_POSTFIX)
   set(CMAKE_DEBUG_POSTFIX d)
 endif()
 
 set(CMAKE_C_FLAGS_RELEASE "-O3")
 set(BUILD_SHARED_LIBS ON)
+
+if(APPLE)
+  if(NOT DEFINED Autoscoper_MACOSX_BUNDLE)
+    set(Autoscoper_MACOSX_BUNDLE ON)
+  endif()
+  mark_as_superbuild(Autoscoper_MACOSX_BUNDLE:BOOL)
+endif()
 
 #-----------------------------------------------------------------------------
 # Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,9 +105,17 @@ if(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   mark_as_superbuild(Autoscoper_OpenCL_MINIMUM_REQUIRED_VERSION:STRING)
   message(STATUS "Setting Autoscoper_OpenCL_MINIMUM_REQUIRED_VERSION to ${Autoscoper_OpenCL_MINIMUM_REQUIRED_VERSION}")
 
+  # This option is specific to "OpenCL-ICD-Loader"
   set(Autoscoper_CL_TARGET_OPENCL_VERSION "120")
   mark_as_superbuild(Autoscoper_CL_TARGET_OPENCL_VERSION:STRING)
   message(STATUS "Setting Autoscoper_CL_TARGET_OPENCL_VERSION to ${Autoscoper_CL_TARGET_OPENCL_VERSION}")
+
+  set(Autoscoper_OPENCL_USE_ICD_LOADER TRUE)
+  if(APPLE)
+    set(Autoscoper_OPENCL_USE_ICD_LOADER FALSE)
+  endif()
+  mark_as_superbuild(Autoscoper_OPENCL_USE_ICD_LOADER:BOOL)
+  message(STATUS "Setting Autoscoper_OPENCL_USE_ICD_LOADER to ${Autoscoper_OPENCL_USE_ICD_LOADER}")
 endif()
 
 #-----------------------------------------------------------------------------

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -4,9 +4,11 @@ set(Autoscoper_DEPENDENCIES
   TIFF
   )
 if(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
-  list(APPEND Autoscoper_DEPENDENCIES
-    OpenCL-ICD-Loader
-    )
+  if(Autoscoper_OPENCL_USE_ICD_LOADER)
+    list(APPEND Autoscoper_DEPENDENCIES
+      OpenCL-ICD-Loader
+      )
+  endif()
 endif()
 
 set(proj ${SUPERBUILD_TOPLEVEL_PROJECT})

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -87,7 +87,7 @@ set(autoscoper_RESOURCES
 )
 QT5_ADD_RESOURCES(autoscoper_RESOURCES_RCC ${autoscoper_RESOURCES})
 
-if(APPLE)
+if(APPLE AND Autoscoper_MACOSX_BUNDLE)
   set(GUI_TYPE MACOSX_BUNDLE)
 endif()
 

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -99,7 +99,7 @@ add_executable(autoscoper  ${GUI_TYPE} ${autoscoper_SOURCES} ${autoscoper_HEADER
   src/ui/autoscoper_resource.qrc
 )
 
-if(CMAKE_VERSION VERSION_LESS "3.20" AND UNIX)
+if(Autoscoper_CONFIGURE_LAUCHER_SCRIPT AND CMAKE_VERSION VERSION_LESS "3.20" AND UNIX)
   set(_launcher_script "autoscoper_set_env.sh")
   add_custom_command(TARGET autoscoper POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E echo "Changing '${_launcher_script}' permissions"

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -1,6 +1,5 @@
 find_package(OpenGL)
 
-#ADD QT4 SUPPORT
 find_package(Qt5 COMPONENTS Core Widgets Gui OpenGL Network REQUIRED)
 set(CMAKE_AUTOMOC ON)
 
@@ -8,7 +7,6 @@ set(autoscoper_SOURCES
   src/main.cpp
 )
 
-#HEADER AND SOURCE FILES FOR UI
 set(autoscoper_FORMS_HEADERS
   src/ui/AutoscoperMainWindow.h
   src/ui/FilterDockWidget.h
@@ -67,7 +65,6 @@ set(autoscoper_FORMS_SOURCES
   src/net/Socket.cpp
 )
 
-#QT DESIGNER UI FILES
 set(autoscoper_FORMS
   src/ui/ui-files/AboutAutoscoper.ui
   src/ui/ui-files/AutoscoperMainWindow.ui

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -99,6 +99,10 @@ add_executable(autoscoper  ${GUI_TYPE} ${autoscoper_SOURCES} ${autoscoper_HEADER
   src/ui/autoscoper_resource.qrc
 )
 
+if(NOT "${Autoscoper_EXECUTABLE_LINK_FLAGS}" STREQUAL "")
+  set_target_properties(autoscoper PROPERTIES LINK_FLAGS ${Autoscoper_EXECUTABLE_LINK_FLAGS})
+endif()
+
 if(Autoscoper_CONFIGURE_LAUCHER_SCRIPT AND CMAKE_VERSION VERSION_LESS "3.20" AND UNIX)
   set(_launcher_script "autoscoper_set_env.sh")
   add_custom_command(TARGET autoscoper POST_BUILD

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -43,13 +43,19 @@ if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   target_include_directories(libautoscoper PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/cutil)
   # Explicitly linking against CUDA_LIBRARIES is already done in "CUDA_ADD_LIBRARY()".
 elseif(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
-  find_package(OpenCLHeaders REQUIRED)
-  find_package(OpenCLICDLoader REQUIRED)
+  if(Autoscoper_OPENCL_USE_ICD_LOADER)
+    find_package(OpenCLHeaders REQUIRED)
+    find_package(OpenCLICDLoader REQUIRED)
+  else()
+    find_package(OpenCL ${Autoscoper_OpenCL_MINIMUM_REQUIRED_VERSION} REQUIRED)
+  endif()
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/opencl/CMakeLists.txt)
   add_library(libautoscoper STATIC ${libautoscoper_SOURCES} ${libautoscoper_HEADERS} ${opencl_SOURCES} ${opencl_HEADERS})
   add_dependencies(libautoscoper ${SHADER_TO_HEADER})
   target_compile_definitions(libautoscoper PUBLIC
-    CL_TARGET_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION}
+    $<$<BOOL:${Autoscoper_OPENCL_USE_ICD_LOADER}>:CL_TARGET_OPENCL_VERSION=${Autoscoper_CL_TARGET_OPENCL_VERSION}>
+    # Silence warning: 'glFunction' is deprecated: first deprecated in macOS 10.14 - OpenGL API deprecated
+    $<$<AND:$<NOT:$<BOOL:${Autoscoper_OPENCL_USE_ICD_LOADER}>>,$<BOOL:${APPLE}>>:GL_SILENCE_DEPRECATION>
   )
   target_link_libraries(libautoscoper PUBLIC
     OpenCL::OpenCL


### PR DESCRIPTION
## Summary

* Fix Slicer extension packaging allowing customizing autoscoper link flags introducing the CMake option `Autoscoper_EXECUTABLE_LINK_FLAGS`.

* Fix support for building on macOS introducing the option `Autoscoper_OPENCL_USE_ICD_LOADER` initialized to `TRUE` on Linux and Windows, and `FALSE` on macOS.

* Ensure `Autoscoper_*_DIR` variables are passed to inner build

* Add support for building Autoscoper as a regular executable on macOS introducing the CMake option `Autoscoper_MACOSX_BUNDLE`.

* Set `autoscoper_set_env.sh` permission flags only if CMake option `Autoscoper_CONFIGURE_LAUCHER_SCRIPT` is `ON`

* Remove obsolete comments from `autoscoper/CMakeLists.txt`