### PR TITLE
COMP: Update TIFF external project explicitly enabling or disabling codecs

### DIFF
--- a/Superbuild/External_TIFF.cmake
+++ b/Superbuild/External_TIFF.cmake
@@ -49,6 +49,17 @@ if((NOT DEFINED TIFF_INCLUDE_DIR
       -Dtiff_BUILD_CONTRIB:BOOL=OFF
       -Dtiff_BUILD_MAN:BOOL=OFF
       -Dtiff_BUILD_HTMLDOC:BOOL=OFF
+      # Codec options
+      -Dlibdeflate:BOOL=OFF
+      -Djbig:BOOL=OFF
+      -Djpeg:BOOL=OFF
+      -Dold-jpeg:BOOL=OFF
+      -Djpeg12:BOOL=OFF
+      -Dlerc:BOOL=OFF
+      -Dlzma:BOOL=OFF
+      -Dwebp:BOOL=OFF
+      -Dzlib:BOOL=ON # Assumed to be available on the system
+      -Dzstd:BOOL=OFF
       # Install directories
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
       -DCMAKE_INSTALL_BINDIR:STRING=${Autoscoper_BIN_DIR}


### PR DESCRIPTION
This change explicitly enables or disables codecs. By disabling unused or unavailable codecs, we can ensure that the library is not built with dependencies that are either not distributed or not available on the target system.

### Before

```
$ otool -L _CPack_Packages/Darwin/TGZ/31807-macosx-amd64-SlicerAutoscoperM-git0172c84-2023-06-23/Slicer.app/Contents/Extensions-31807/SlicerAutoscoperM/lib/Slicer-5.3/libtiff.5.8.0.dylib 
_CPack_Packages/Darwin/TGZ/31807-macosx-amd64-SlicerAutoscoperM-git0172c84-2023-06-23/Slicer.app/Contents/Extensions-31807/SlicerAutoscoperM/lib/Slicer-5.3/libtiff.5.8.0.dylib:
	@rpath/Extensions-31807/SlicerAutoscoperM/lib/Slicer-5.3/libtiff.5.8.0.dylib (compatibility version 5.0.0, current version 5.8.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/local/opt/zstd/lib/libzstd.1.dylib (compatibility version 1.0.0, current version 1.5.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

### After

```
$ otool -L _CPack_Packages/Darwin/TGZ/31807-macosx-amd64-SlicerAutoscoperM-git0172c84-2023-06-23/Slicer.app/Contents/Extensions-31807/SlicerAutoscoperM/lib/Slicer-5.3/libtiff.5.8.0.dylib 
_CPack_Packages/Darwin/TGZ/31807-macosx-amd64-SlicerAutoscoperM-git0172c84-2023-06-23/Slicer.app/Contents/Extensions-31807/SlicerAutoscoperM/lib/Slicer-5.3/libtiff.5.8.0.dylib:
	@rpath/Extensions-31807/SlicerAutoscoperM/lib/Slicer-5.3/libtiff.5.8.0.dylib (compatibility version 5.0.0, current version 5.8.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)

```
