### PR TITLE
Add option for thicker axis lines for accessibility

### DIFF
--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -1981,6 +1981,22 @@ void AutoscoperMainWindow::on_actionShow_world_view_triggered(bool checked){
   }
 }
 
+void AutoscoperMainWindow::on_actionThick_Lines_Mode_triggered(bool checked)
+{
+  // Check if we have at least one Manipluator
+  if (manipulator.size() == 0) {
+    return;
+  }
+
+  // Set Thick Lines Mode for all Manipulators
+  for(Manip3D* manip3D: manipulator) {
+    manip3D->setThickLinesMode(checked);
+  }
+
+  // Redraw
+  redrawGL();
+}
+
 //Toolbar
 void AutoscoperMainWindow::on_toolButtonOpenTrial_clicked(){
   save_trial_prompt();

--- a/autoscoper/src/ui/AutoscoperMainWindow.h
+++ b/autoscoper/src/ui/AutoscoperMainWindow.h
@@ -245,6 +245,7 @@ class AutoscoperMainWindow : public QMainWindow{
     //View
     void on_actionLayoutCameraViews_triggered(bool checked);
     void on_actionShow_world_view_triggered(bool checked);
+    void on_actionThick_Lines_Mode_triggered(bool checked);
 
 
     // Extra

--- a/autoscoper/src/ui/Manip3D.cpp
+++ b/autoscoper/src/ui/Manip3D.cpp
@@ -146,7 +146,8 @@ Manip3D::Manip3D()
       modelview_(Mat4d::eye()),
       selection_(NONE),
       point1_(Vec3d::zero()),
-      point2_(Vec3d::zero())
+      point2_(Vec3d::zero()),
+      is_thick_lines_mode_(false)
 {
     viewport_[0] = 0;
     viewport_[1] = 0;
@@ -306,6 +307,11 @@ void Manip3D::on_mouse_release(int x, int y)
     transform2_ = Mat4d::eye();
 }
 
+void Manip3D::setThickLinesMode(bool checked)
+{
+    is_thick_lines_mode_ = checked;
+}
+
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~// Private Functions //~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 void Manip3D::draw_axes() const
@@ -354,6 +360,10 @@ void Manip3D::draw_axes() const
 
     // Draw x-axis if the view angle is large enough
 
+
+    if (this->is_thick_lines_mode_)
+      glLineWidth(5.0); // For thick lines mode
+
     if (view_angle.x > min_view_angle) {
         if (selection_ == NONE || selection_ == X || selection_ == VIEW_PLANE) {
             if (selection_ == X) {
@@ -369,7 +379,7 @@ void Manip3D::draw_axes() const
             glDisable(GL_LIGHTING);
             glBegin(GL_LINES);
             glVertex3d(0.0,0.0,0.0);
-            glVertex3d(size_,0.0,0.0);
+            glVertex3d(size_-5,0.0,0.0);
             glEnd();
             glPopAttrib();
 
@@ -409,7 +419,7 @@ void Manip3D::draw_axes() const
             glDisable(GL_LIGHTING);
             glBegin(GL_LINES);
             glVertex3d(0.0,0.0,0.0);
-            glVertex3d(0.0,size_,0.0);
+            glVertex3d(0.0,size_-5,0.0);
             glEnd();
             glPopAttrib();
 
@@ -447,7 +457,7 @@ void Manip3D::draw_axes() const
             glDisable(GL_LIGHTING);
             glBegin(GL_LINES);
             glVertex3d(0.0,0.0,0.0);
-            glVertex3d(0.0,0.0,size_);
+            glVertex3d(0.0,0.0,size_-5);
             glEnd();
             glPopAttrib();
 
@@ -577,6 +587,9 @@ void Manip3D::draw_gimbals() const
     }
     glEnd();
 
+    if (this->is_thick_lines_mode_)
+      glLineWidth(5.0); // For thick lines mode
+
     // Draw x-axis gimbal
 
     if (selection_ == X) {
@@ -585,8 +598,8 @@ void Manip3D::draw_gimbals() const
     else {
         glColor4dv(red);
     }
-    glBegin(GL_LINE_STRIP);
-    for (int i = 0; i < 32; ++i) {
+    glBegin(GL_LINE_LOOP);
+    for (int i = 0; i < 64; ++i) {
         float theta = alpha.x+M_PI*i/(float)(32-1);
         glVertex3d(0.0,size_*cos(theta),size_*sin(theta));
     }
@@ -600,8 +613,8 @@ void Manip3D::draw_gimbals() const
     else {
         glColor4dv(green);
     }
-    glBegin(GL_LINE_STRIP);
-    for (int i = 0; i < 32; ++i) {
+    glBegin(GL_LINE_LOOP);
+    for (int i = 0; i < 64; ++i) {
         float theta = alpha.y+M_PI*i/(float)(32-1);
         glVertex3d(size_*cos(theta),0.0,size_*sin(theta));
     }
@@ -615,8 +628,8 @@ void Manip3D::draw_gimbals() const
     else {
         glColor4dv(blue);
     }
-    glBegin(GL_LINE_STRIP);
-    for (int i = 0; i < 32; ++i) {
+    glBegin(GL_LINE_LOOP);
+    for (int i = 0; i < 64; ++i) {
         float theta = alpha.z+M_PI*i/(float)(32-1);
         glVertex3d(size_*cos(theta),size_*sin(theta),0.0);
     }

--- a/autoscoper/src/ui/Manip3D.hpp
+++ b/autoscoper/src/ui/Manip3D.hpp
@@ -163,6 +163,8 @@ public:
 
     void on_mouse_release(int x, int y);
 
+    void setThickLinesMode(bool checked);
+
 private:
 
     void draw_axes() const;
@@ -207,6 +209,8 @@ private:
   bool movePivot_;
 
   double pivotSize_;
+
+  bool is_thick_lines_mode_;
 };
 
 #endif // MANIP_3D_HPP

--- a/autoscoper/src/ui/ui-files/AutoscoperMainWindow.ui
+++ b/autoscoper/src/ui/ui-files/AutoscoperMainWindow.ui
@@ -467,8 +467,15 @@ Dialog</string>
     <property name="title">
      <string>View</string>
     </property>
+    <widget class="QMenu" name="menuAccessiblity">
+     <property name="title">
+      <string>Accessiblity</string>
+     </property>
+     <addaction name="actionThick_Lines_Mode"/>
+    </widget>
     <addaction name="actionShow_world_view"/>
     <addaction name="actionLayoutCameraViews"/>
+    <addaction name="menuAccessiblity"/>
    </widget>
    <widget class="QMenu" name="menuAdvanced_Tool">
     <property name="title">
@@ -700,6 +707,14 @@ Dialog</string>
   <action name="actionExport_Full_DRR_Image">
    <property name="text">
     <string>Export Full DRR Image</string>
+   </property>
+  </action>
+  <action name="actionThick_Lines_Mode">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Thick Line Mode</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
* Adds new menu `Accessibility` under the `View` dropdown with a toggleable option for thicker axis lines
* Addresses part of Issue #140 

## Menu

![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/d6f382d7-9ee6-4bd7-929b-76e2a515d53b)

## Axis Lines

| | Normal Lines | Thick Lines |
| --- | --- | --- |
| Translation | ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/a2ba64ed-03b8-466d-9690-548404ae8008) | ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/f88c1dbd-d9f1-49df-9fdf-3650d290c6c9) | 
| Rotation | ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/9a35a262-fb16-4b20-b445-1c4465587340) | ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/1f6b1569-232c-4b0f-ac23-5e6599359a1d) | 
