### PR TITLE
Fix progress bar not updating

### DIFF
--- a/autoscoper/src/ui/TrackingOptionsDialog.cpp
+++ b/autoscoper/src/ui/TrackingOptionsDialog.cpp
@@ -144,8 +144,7 @@ void TrackingOptionsDialog::frame_optimize()
       mainwindow->setFrame(mainwindow->getTracker()->trial()->frame);
 
          //update progress bar
-
-         double value = abs(to_frame-from_frame) > 0 ? abs(frame-from_frame)/ abs(to_frame-from_frame) : 0;
+     double value = abs(to_frame - from_frame) > 0 ? fabs(frame - from_frame) / fabs(to_frame - from_frame) : 0;
      int progress = value *100;
      diag->progressBar->setValue(progress);
 


### PR DESCRIPTION
* Bug was caused by incorrect types being used (dividing two integers instead of two doubles)
* Bug was initially introduced during the initial implementation of the progress bar (See 681c3c7)
* Merging this PR will close #146 
* #131 Will be closed once the cancel button is working
![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/6ed872a0-c2da-4162-90f0-371efca1f1f2)
