### PR TITLE
STYLE: Update range for Y,P,R KeyCurves

### DIFF
--- a/libautoscoper/src/KeyCurve.cpp
+++ b/libautoscoper/src/KeyCurve.cpp
@@ -50,6 +50,12 @@ void KeyCurve::insert(int time)
 
 void KeyCurve::insert(int time, float value)
 {
+  // If curve type is ROLL, PITCH or YAW, then need to convert from [-180,180] to [0,360]
+  if (type == ROLL_CURVE || type == PITCH_CURVE || type == YAW_CURVE) {
+    if (value < 0) {
+      value += 360;
+    }
+  }
     Key key;
     key.value = value;
     key.in_tangent_type = SMOOTH;


### PR DESCRIPTION
* Keycurves for yaw pitch and roll are now displayed in the range [0,360] instead of [-180,180]
* This change ONLY affects the curve display, all backend calculations are still carried out in [-180,180]
* Exporting tracking data in xyzypr format is also still in the range [-180,180]
* Closes #149 

![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/bddd7ae0-f330-41fe-9c84-c8f2baf5f50c)
