### PR TITLE
ENH: Simplify protocol versioning using ordinals instead of Semver

### DIFF
--- a/autoscoper/src/net/Socket.cpp
+++ b/autoscoper/src/net/Socket.cpp
@@ -49,9 +49,7 @@
 #include "filesystem_compat.hpp"
 #include <QTcpSocket>
 
-#define AUTOSCOPER_SOCKET_VERSION_MAJOR 1
-#define AUTOSCOPER_SOCKET_VERSION_MINOR 0
-#define AUTOSCOPER_SOCKET_VERSION_PATCH 0
+#define AUTOSCOPER_SOCKET_VERSION 1
 
 Socket::Socket(AutoscoperMainWindow* mainwindow, unsigned long long int listenPort) : m_mainwindow(mainwindow)
 {
@@ -68,13 +66,11 @@ Socket::~Socket()
   }
 }
 
-int constexpr Socket::versionMajor() { return AUTOSCOPER_SOCKET_VERSION_MAJOR; }
-int constexpr Socket::versionMinor() { return AUTOSCOPER_SOCKET_VERSION_MINOR; }
-int constexpr Socket::versionPatch() { return AUTOSCOPER_SOCKET_VERSION_PATCH; }
+int constexpr Socket::version() { return AUTOSCOPER_SOCKET_VERSION; }
 
 QString Socket::versionString()
 {
-  return QString("%1.%2.%3").arg(QString::number(Socket::versionMajor()), QString::number(Socket::versionMinor()), QString::number(Socket::versionPatch()));
+  return QString::number(Socket::version());
 }
 
 void Socket::handleMessage(QTcpSocket * connection, char* data, qint64 length)
@@ -377,8 +373,9 @@ void Socket::handleMessage(QTcpSocket * connection, char* data, qint64 length)
   case 16:
     // get the version of the server
     {
+      int version = this->version();
       QByteArray array = QByteArray(1, 16);
-      array.append(versionString().toLocal8Bit());
+      array.append((char*)&version, sizeof(int));
       connection->write(array);
     }
     break;

--- a/autoscoper/src/net/Socket.h
+++ b/autoscoper/src/net/Socket.h
@@ -58,16 +58,10 @@ public:
   Socket(AutoscoperMainWindow* mainwindow, unsigned long long int listenPort);
   ~Socket();
 
-  /// @{
-  /// The Autoscoper Socket major/minor/patch version.
-  ///
-  /// \see https://semver.org/spec/v2.0.0.html for details.
-  int constexpr versionMajor();
-  int constexpr versionMinor();
-  int constexpr versionPatch();
-  /// @}
+  /// The Autoscoper Socket version.
+  int constexpr version();
 
-  /// The Autoscoper Socket version formatted as "MAJOR.MINOR.PATCH".
+  /// The Autoscoper Socket version formatted as "NUMBER".
   QString versionString();
 
 private:

--- a/scripts/python/PyAutoscoper/connect.py
+++ b/scripts/python/PyAutoscoper/connect.py
@@ -1,9 +1,8 @@
 import os
 import socket
 import struct
-from packaging.version import Version, parse as parse_version
 
-EXPECTED_SERVER_VERSION = Version("1.0.0")
+EXPECTED_SERVER_VERSION = 1
 
 
 class AutoscoperServerError(Exception):
@@ -127,10 +126,10 @@ class AutoscoperConnection:
 
         Called automatically upon init.
 
-        :raises AutoscoperServerVersionMismatch: If the server version is not compatible with the client version
+        :raises AutoscoperServerVersionMismatch: If the server version does not match the client version
         """
         response = self._send_command(0x10)  # 16
-        server_version = parse_version(response[1:].decode("utf-8"))  # version string formatted as "MAJOR.MINOR.PATCH"
+        server_version = struct.unpack("i", response[1:])[0]  # version string formatted as "NUMBER"
 
         if server_version != EXPECTED_SERVER_VERSION:
             raise AutoscoperServerVersionMismatch(server_version)


### PR DESCRIPTION
> Using semver for network protocols can be confusing. It's unclear
> what a change implies, even if backward compatible. This leads to
> unpredictable results when peers with different versions communicate.
> We rely on explicit, verbatim protocol negotiation instead. Semver is
> removed and replaced with ordinals that require explicit agreement
> without enforcing a specific policy for changes.

Adapted from https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#why-do-we-version-protocol-strings-with-ordinals-instead-of-semver

This is a follow-up of:
* https://github.com/BrownBiomechanics/Autoscoper/pull/122