### PR TITLE
Strip trailing whitespaces

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ name: Upload Python Package
 
 on:
   push:
-    tags: 
+    tags:
     - 'python-client-v*'
 
 permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
   - id: check-toml
   - id: check-yaml
   - id: debug-statements
+  - id: trailing-whitespace
 
 - repo: https://github.com/psf/black
   rev: "23.3.0" # Keep in sync with blacken-docs

--- a/BUILD.md
+++ b/BUILD.md
@@ -62,7 +62,7 @@ _These instructions are untested and maybe obsolete._
 
 1. Clone the [GitHub repository](https://github.com/BrownBiomechanics/Autoscoper)
 2. Install [Docker](https://www.docker.com/products/docker-desktop)
-3. If running Windows Subsystem for Linux (WSL), install [VcXsrv Windows X Server](https://sourceforge.net/projects/vcxsrv/) for GUI passthrough. 
+3. If running Windows Subsystem for Linux (WSL), install [VcXsrv Windows X Server](https://sourceforge.net/projects/vcxsrv/) for GUI passthrough.
 4. Open a terminal and navigate to the docker subfolder of the repository
 5. Run `docker build -t "autoscoper_dev_ubuntu:latest" -f ./UbuntuDockerFile .`
 6. Find your IP address (using `ipconfig` on Windows or `ifconfig` on Unix)

--- a/CMake/autoscoper_set_env.bat.in
+++ b/CMake/autoscoper_set_env.bat.in
@@ -1,5 +1,5 @@
 @echo off
-setlocal enabledelayedexpansion	
+setlocal enabledelayedexpansion
 set argCount=0
 for %%x in (%*) do (
   set /A argCount+=1

--- a/Documentation/_static/css/custom.css
+++ b/Documentation/_static/css/custom.css
@@ -1,4 +1,4 @@
 /* Make the content take up the whole screen rather than just half */
 .wy-nav-content{
     max-width: 100%;
-} 
+}

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -30,7 +30,7 @@ A series of tutorials are available to help you get started using AutoscoperM. T
 
 Sample data is available for download from the [SlicerAutoscoperM Sample Data](/tutorials/loading-and-tracking.md#downloading-sample-data) page. Currently available sample data includes:
 
-* Wrist BVR data - This was part of the data used in the [Akhbari et al. 2019](https://www.sciencedirect.com/science/article/abs/pii/S0021929019303847) paper. 
+* Wrist BVR data - This was part of the data used in the [Akhbari et al. 2019](https://www.sciencedirect.com/science/article/abs/pii/S0021929019303847) paper.
   * Three frames of movement are included in the sample data.
   * Four DRRs are included in the sample data. The radius, ulna, third meta-carpal, and a combined second and third meta-carpal are included.
 * Knee BVR data - This data was provided by Jill Beveridge.

--- a/Documentation/tutorials/loading-and-tracking.md
+++ b/Documentation/tutorials/loading-and-tracking.md
@@ -25,7 +25,7 @@ Once downloaded, switch to the `AutoscoperM` module to begin tracking. This modu
 ## Launching Autoscoper and Loading Sample Data
 
 ```{warning}
-Launching Autoscoper for the first time on Windows may require you to allow the program to run. 
+Launching Autoscoper for the first time on Windows may require you to allow the program to run.
 ```
 
 Once the `AutoscoperM` module is open, click the `Launch Autoscoper` button to launch Autoscoper. This will open a new window with the `Autoscoper` interface. Once Autoscoper is open, you can load the sample data by clicking one of the buttons in the Sample Data section of the interface. The buttons are labeled `Load Wrist Data`, `Load Knee Data`, and `Load Ankle Data`.

--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -164,7 +164,7 @@ AutoscoperMainWindow::AutoscoperMainWindow(bool skipGpuDevice, QWidget *parent) 
   ui->actionOpen_Sample_Wrist->setEnabled(true);
   ui->actionOpen_Sample_Knee->setEnabled(true);
   ui->actionOpen_Sample_Ankle->setEnabled(true);
-#endif 
+#endif
 }
 
 AutoscoperMainWindow::~AutoscoperMainWindow(){

--- a/scripts/matlab/AutoscoperConnection.m
+++ b/scripts/matlab/AutoscoperConnection.m
@@ -6,9 +6,9 @@ classdef AutoscoperConnection
     end
     methods
         function obj = AutoscoperConnection(address)
-            % Creates a connection to the Autoscoper 
+            % Creates a connection to the Autoscoper
             % supports single instance connection only
-           
+
             v_old = isMATLABReleaseOlderThan("R2022a");
             if v_old
                 obj.socket_descriptor = tcpip(obj.address, obj.port, 'NetworkRole', 'client');
@@ -34,7 +34,7 @@ classdef AutoscoperConnection
             % Loads a trial
             % path_to_cfg_file : full path to config (.cfg) file
             %   fail if incorrect filepath/ no file found
-            
+
             fwrite(obj.socket_descriptor, [1 path_to_cfg_file]);
             while obj.socket_descriptor.BytesAvailable == 0
                 pause(1)
@@ -55,7 +55,7 @@ classdef AutoscoperConnection
             % is_cm: 1 if the tracking data is in cm, 0 if it is in mm
             % is_rad: 1 if the tracking data is in radians, 0 if it is in degrees
             % interpY: 1 to interpolate(Spline), 0 to leave as is
-            
+
             if nargin < 3
                 error('Not enough input arguments')
             end
@@ -80,7 +80,7 @@ classdef AutoscoperConnection
             fwrite(obj.socket_descriptor, [2 typecast(int32(volNum),'uint8') typecast(int32(is_matrix),'uint8'),...
                 typecast(int32(is_rows),'uint8') typecast(int32(is_csv),'uint8') typecast(int32(is_cm),'uint8'),...
                 typecast(int32(is_rad),'uint8') typecast(int32(interpY),'uint8') tra_fileName]);
-            
+
             while obj.socket_descriptor.BytesAvailable == 0
                 pause(1)
             end
@@ -303,7 +303,7 @@ classdef AutoscoperConnection
             if nargin < 11
                 cf_model = 0;
             end
-            fwrite(obj.socket_descriptor, [11 typecast(int32(volNum),'uint8') typecast(int32(frameNum),'uint8') typecast(int32(repeats),'uint8') typecast(int32(max_itr),'uint8') typecast(double(min_lim),'uint8') typecast(double(max_lim),'uint8') typecast(int32(max_stall_itr),'uint8') typecast(int32(dframe),'uint8') typecast(int32(opt_method),'uint8') typecast(int32(cf_model),'uint8')]);    
+            fwrite(obj.socket_descriptor, [11 typecast(int32(volNum),'uint8') typecast(int32(frameNum),'uint8') typecast(int32(repeats),'uint8') typecast(int32(max_itr),'uint8') typecast(double(min_lim),'uint8') typecast(double(max_lim),'uint8') typecast(int32(max_stall_itr),'uint8') typecast(int32(dframe),'uint8') typecast(int32(opt_method),'uint8') typecast(int32(cf_model),'uint8')]);
             while obj.socket_descriptor.BytesAvailable == 0
                 pause(1)
             end
@@ -324,7 +324,7 @@ classdef AutoscoperConnection
             % Performs optimization on a range of frames
             % Only obj, volNum, startframe, and endframe are required
             % all other parameters are optional
-            
+
             %volNum: volume to be optimized over the designated range
             % startframe: the first frame to optimize
             % endframe: the last frame to optimize
@@ -378,7 +378,7 @@ classdef AutoscoperConnection
         function ncc_out = getNCC_Sum(obj,volNum,pose)
             % Gets the sum of the NCC for the given volNum and pose
 
-            % volNum: the volume number to get the NCC for 
+            % volNum: the volume number to get the NCC for
             % pose: the pose to get the NCC for
 
             if nargin < 3
@@ -400,7 +400,7 @@ classdef AutoscoperConnection
         function ncc_out = getNCC_This_Frame(obj,volNum,frameNum)
             % Gets the NCC for the given volNum and frame
 
-            % volNum: the volume number to get the NCC for 
+            % volNum: the volume number to get the NCC for
             % frame: the frame to get the NCC for
 
             if nargin < 3

--- a/scripts/matlab/README.md
+++ b/scripts/matlab/README.md
@@ -24,12 +24,12 @@ loadFilters(aobj, -1, filterFileName);
 
 %if seeding poses available
 for vNum = 0: length(myVolumeList)-1
-	loadTrackingData(aobj, vNum, [trackDataInFileName,myVolumeList{vNum}]); 
+	loadTrackingData(aobj, vNum, [trackDataInFileName,myVolumeList{vNum}]);
 
 	trackingDialog(vNum, tf, numberOfFrames);
-	
+
 	saveTrackingData(vNum, [saveDataFileName,myVolumeList{vNum}]);
-end	
+end
 closeConnection(aobj);
 ```
 
@@ -62,7 +62,7 @@ This function has the following parameter:
 * path_to_cfg_file: The path to the configuration file.
 
 ### Load Tracking Data
-  
+
 ```matlab
 connection.loadTrackingData(volNum, tra_fileName, is_matrix, is_rows, is_csv, is_cm, is_rad);
 OR
@@ -83,7 +83,7 @@ This function has the following parameters:
 
 
   ### Save Tracking Data
-  
+
 ```matlab
 connection.saveTrackingData(volNum, tra_fileName, save_as_matrix, save_as_rows, save_with_commas, convert_mm_to_cm, convert_deg_to_rad, interpY);
 OR
@@ -106,7 +106,7 @@ This function has the following optional parameters:
 
 
 ### Load Filters
-  
+
 ```matlab
 connection.loadFilters(camera, filter_file);
 OR
@@ -118,10 +118,10 @@ This will load filters from the specified file. The filters file is a `.vie` fil
 This function has the following parameters:
 
 * camera: The camera index to load the filters for. (index base 0)  -1 for all
-* filter_file: The path anf fielname to the filters file. 
+* filter_file: The path anf fielname to the filters file.
 
 ### Set Frame
-  
+
 ```matlab
 connection.setFrame(frameNum);
 OR
@@ -135,7 +135,7 @@ This function has the following parameter:
 * frameNum: The frame to set.
 
 ### Get Pose
-    
+
 ```matlab
 pose = connection.getPose(volNum, frameNum);
 OR
@@ -154,7 +154,7 @@ This function returns the following:
 * pose: The pose for the specified volume at the specified frame.
 
 ### Set Pose
-    
+
 ```matlab
 connection.setPose(volume, frame, pose);
 OR
@@ -170,7 +170,7 @@ This function has the following parameters:
 * pose: The pose to set.
 
 ### Get NCC
-    
+
 ```matlab
 ncc = connection.getNCC(voNum, pose);
 OR
@@ -185,11 +185,11 @@ This function has the following parameters:
 * pose: The pose to get the NCC at. (see getPose xyzrpy)
 
 This function returns the following:
-  
+
 * ncc: The NCC for the specified volume at the specified frame.
 
 ### Set Background
-    
+
 ```matlab
 connection.setBackground(threshold);
 OR
@@ -203,7 +203,7 @@ This function has the following parameter:
 * threshold: The threshold to set.
 
 ### Get Image Cropped
-    
+
 ```matlab
 connection.getImageCropped(volume, camera, pose);
 ```
@@ -242,7 +242,7 @@ This function has the following parameters:
 * cf_model: Optional. The cost function model, 0 for NCC, 1 for Sum of Absolute Differences. Default: 0
 
 ### Tracking Dialog
-  
+
 ```matlab
 connection.trackingDialog(volNum, startframe, endframe, repeats, max_itr, min_lim, max_lim, max_stall_itr, dframe, opt_method, cf_model);
 OR
@@ -266,7 +266,7 @@ This function has the following parameters:
 * cf_model: Optional. The cost function model, 0 for NCC, 1 for Sum of Absolute Differences. Default: 0
 
 ### Get NCC Sum
-    
+
 ```matlab
 ncc_sum = connection.getNCC_Sum(volNum, pose);
 OR
@@ -278,7 +278,7 @@ This will get the NCC sum for the specified volume in the specified pose (set ge
 This function has the following parameters:
 
 * volNum: The volume to get the NCC sum for.
-* pose: The pose to get the NCC sum at. 
+* pose: The pose to get the NCC sum at.
 
 ### Get NCC This Frame
 
@@ -298,7 +298,7 @@ This function has the following parameters:
 *returns a three element double- the ncc values returned from getNCC  , and thier product
 
 ### Close Connection
-  
+
 ```matlab
 connection.closeConnection();
 ```


### PR DESCRIPTION
Strip all trailing white spaces and enable "trailing-whitespace" pre-commit hook.
   
See https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace
    
For future reference, the following one liner was used:

```bash
for file in $(fd -t f -E *.tif -E *.png -E *.gif) $(fd -t f . .github/*); do
  sed -i 's/[ \t]*$//' "$file";
done
```
