### PR TITLE
DOC: Ensure generated PyAutoscoper API documentation is current

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -3,7 +3,11 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+import sys
 from datetime import date
+
+sys.path.insert(0, os.path.abspath("../scripts/python"))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -6,4 +6,3 @@ sphinx-notfound-page
 sphinx-rtd-theme
 sphinxcontrib-autoprogram
 sphinxcontrib-bibtex
-PyAutoscoper


### PR DESCRIPTION
This commit ensures that the generated API documentation using `automodule` is based of the PyAutoscoper version available along side the markdown files and not the latest version published on PyPI.

````rst
```{eval-rst}
.. automodule:: PyAutoscoper.connect
   :members:
   :undoc-members:
   :show-inheritance:
```
````