### PR TITLE
BUG: Fix typo associated with OptimizationMethod enum

### DIFF
--- a/Documentation/socket-control-libraries/pyautoscoper.md
+++ b/Documentation/socket-control-libraries/pyautoscoper.md
@@ -144,7 +144,7 @@ The `trackingDialog` method takes at least three arguments:
 * `min_lim`: The minimum limit for the PSO movement. Defaults to -3.0.
 * `max_lim`: The maximum limit for the PSO movement. Defaults to 3.0.
 * `max_stall_itr`: The maximum number of iterations to stall the optimization. Defaults to 25.
-* `opt_method`: The {const}`~PyAutoscoper.connect.OptimizationMethod` to use. Defaults to {const}`~PyAutoscoper.connect.OptimizationMethod.PARTICAL_SWARM_OPTIMIZATION`.
+* `opt_method`: The {const}`~PyAutoscoper.connect.OptimizationMethod` to use. Defaults to {const}`~PyAutoscoper.connect.OptimizationMethod.PARTICLE_SWARM_OPTIMIZATION`.
 * `cf_model` : The {const}`~PyAutoscoper.connect.CostFunction` to use for evaluating the optimization. Defaults to {const}`~PyAutoscoper.connect.CostFunction.NORMALIZED_CROSS_CORRELATION`.
 
 ```{literalinclude} ../../scripts/python/examples/pyautoscoper-examples.py

--- a/scripts/python/PyAutoscoper/connect.py
+++ b/scripts/python/PyAutoscoper/connect.py
@@ -16,7 +16,7 @@ class CostFunction(Enum):
 class OptimizationMethod(Enum):
     """Enum for the different optimization methods available in PyAutoscoper."""
 
-    PARTICAL_SWARM_OPTIMIZATION = 0
+    PARTICLE_SWARM_OPTIMIZATION = 0
     DOWNHILL_SIMPLEX = 1
 
 
@@ -507,7 +507,7 @@ class AutoscoperConnection:
         min_lim=-3.0,
         max_lim=3.0,
         max_stall_itr=25,
-        opt_method=OptimizationMethod.PARTICAL_SWARM_OPTIMIZATION,
+        opt_method=OptimizationMethod.PARTICLE_SWARM_OPTIMIZATION,
         cf_model=CostFunction.NORMALIZED_CROSS_CORRELATION,
     ):
         """

--- a/scripts/python/examples/pyautoscoper-examples.py
+++ b/scripts/python/examples/pyautoscoper-examples.py
@@ -46,7 +46,7 @@ autoscoperSocket.optimizeFrame(
     max_lim=1.0,
     max_stall_itr=10,
     dframe=1,
-    opt_method=OptimizationMethod.PARTICAL_SWARM_OPTIMIZATION,
+    opt_method=OptimizationMethod.PARTICLE_SWARM_OPTIMIZATION,
     cf_model=CostFunction.NORMALIZED_CROSS_CORRELATION,
 )
 # [Example 5 - End]
@@ -95,7 +95,7 @@ for volume in range(3):
             max_lim=1.0,
             max_stall_itr=10,
             dframe=1,
-            opt_method=OptimizationMethod.PARTICAL_SWARM_OPTIMIZATION,
+            opt_method=OptimizationMethod.PARTICLE_SWARM_OPTIMIZATION,
             cf_model=CostFunction.NORMALIZED_CROSS_CORRELATION,
         )
 


### PR DESCRIPTION
This is a follow-up of:
* https://github.com/BrownBiomechanics/Autoscoper/pull/161