### PR TITLE
COMP: Explicitly reference "std" namespace for getline function

### DIFF
--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -998,10 +998,10 @@ void AutoscoperMainWindow::load_tracking_results(QString filename, bool save_as_
 
   double m[16];
   std::string line, value;
-  for (int i = 0; i < tracker->trial()->num_frames && getline(file, line); ++i) {
+  for (int i = 0; i < tracker->trial()->num_frames && std::getline(file, line); ++i) {
     std::istringstream lineStream(line);
     for (int k = start; k < stop; k++){
-      for (int j = 0; j < (save_as_matrix ? 16 : 6) && getline(lineStream, value, s); ++j) {
+      for (int j = 0; j < (save_as_matrix ? 16 : 6) && std::getline(lineStream, value, s); ++j) {
         std::istringstream valStream(value);
         valStream >> m[j];
       }

--- a/libautoscoper/src/Camera.cpp
+++ b/libautoscoper/src/Camera.cpp
@@ -136,7 +136,7 @@ void Camera::loadMayaCam1(const std::string& mayacam)
     for (int i = 0; i < 5 && safeGetline(file, csv_line); ++i) {
       int read_count = 0;
       std::istringstream csv_line_stream(csv_line);
-      for (int j = 0; j < 3 && getline(csv_line_stream, csv_val, ','); ++j) {
+      for (int j = 0; j < 3 && std::getline(csv_line_stream, csv_val, ','); ++j) {
         std::istringstream csv_val_stream(csv_val);
         if (!(csv_val_stream >> csv_vals[i][j])) {
           break;
@@ -289,7 +289,7 @@ void Camera::loadMayaCam1(const std::string& mayacam)
         case 1: //size
         {
           int read_count = 0;
-          for (int j = 0; j < 2 && getline(csv_line_stream, csv_val, ','); ++j) {
+          for (int j = 0; j < 2 && std::getline(csv_line_stream, csv_val, ','); ++j) {
             std::istringstream csv_val_stream(csv_val);
             if (!(csv_val_stream >> size_[j])) {
               break;
@@ -307,7 +307,7 @@ void Camera::loadMayaCam1(const std::string& mayacam)
         case 6:
         {
           int read_count = 0;
-          for (int j = 0; j < 3 && getline(csv_line_stream, csv_val, ','); ++j) {
+          for (int j = 0; j < 3 && std::getline(csv_line_stream, csv_val, ','); ++j) {
             std::istringstream csv_val_stream(csv_val);
             if (!(csv_val_stream >> K[j][i - 4])) {
               break;
@@ -325,7 +325,7 @@ void Camera::loadMayaCam1(const std::string& mayacam)
         case 11:
         {
           int read_count = 0;
-          for (int j = 0; j < 3 && getline(csv_line_stream, csv_val, ','); ++j) {
+          for (int j = 0; j < 3 && std::getline(csv_line_stream, csv_val, ','); ++j) {
             std::istringstream csv_val_stream(csv_val);
             if (!(csv_val_stream >> rotation[j][i - 9])) {
               break;

--- a/libautoscoper/src/Trial.cpp
+++ b/libautoscoper/src/Trial.cpp
@@ -85,7 +85,7 @@ namespace xromm
     std::vector<std::string> optimizationOffsets;
 
     std::string line, key, value;
-    while (getline(file, line)) {
+    while (std::getline(file, line)) {
 
       // Skip blank lines and commented lines.
       if (line.size() == 0 || line[0] == '\n' || line[0] == '#') {
@@ -93,33 +93,33 @@ namespace xromm
       }
 
       std::istringstream lineStream(line);
-      getline(lineStream, key, ' ');
+      std::getline(lineStream, key, ' ');
       if (key.compare("mayaCam_csv") == 0) {
-        getline(lineStream, value);
+        std::getline(lineStream, value);
         mayaCams.push_back(value);
       }
       else if (key.compare("CameraRootDir") == 0) {
-        getline(lineStream, value);
+        std::getline(lineStream, value);
         camRootDirs.push_back(value);
       }
       else if (key.compare("VolumeFile") == 0) {
-        getline(lineStream, value);
+        std::getline(lineStream, value);
         volumeFiles.push_back(value);
       }
       else if (key.compare("VolumeFlip") == 0) {
-        getline(lineStream, value);
+        std::getline(lineStream, value);
         volumeFlips.push_back(value);
       }
       else if (key.compare("VoxelSize") == 0) {
-        getline(lineStream, value);
+        std::getline(lineStream, value);
         voxelSizes.push_back(value);
       }
       else if (key.compare("RenderResolution") == 0) {
-        getline(lineStream, value);
+        std::getline(lineStream, value);
         renderResolution.push_back(value);
       }
       else if (key.compare("OptimizationOffsets") == 0) {
-        getline(lineStream, value);
+        std::getline(lineStream, value);
         optimizationOffsets.push_back(value);
       }
     }


### PR DESCRIPTION
This commit is a follow-up of 4998f5b5d (COMP: Explicitly reference "std" namespace).

See https://cplusplus.com/reference/string/string/getline/