### PR TITLE
ENH: Add "Version" key to trial config file

### DIFF
--- a/libautoscoper/src/Trial.hpp
+++ b/libautoscoper/src/Trial.hpp
@@ -99,6 +99,7 @@ private:
 
 
     void parse(std::ifstream& file,
+               std::vector<int>& version,
                std::vector<std::string>& mayaCams,
                std::vector<std::string>& camRootDirs,
                std::vector<std::string>& volumeFiles,
@@ -106,6 +107,8 @@ private:
                std::vector<std::string>& volumeFlips,
                std::vector<std::string>& renderResolution,
                std::vector<std::string>& optimizationOffsets);
+
+    void parseVersion(const std::string& text, std::vector<int>& version);
 
     void validate(const std::vector<std::string>& mayaCams,
                   const std::vector<std::string>& camRootDirs,


### PR DESCRIPTION
File without any "Version" key are considered to be version 1.0

This change is done anticipating the introduction of relative path support.

This pull request was created from work originally done in:
* https://github.com/BrownBiomechanics/Autoscoper/pull/125
* https://github.com/BrownBiomechanics/Autoscoper/pull/178