### PR TITLE
COMP: Fix compile error C2440 in Trial.cpp

### DIFF
--- a/libautoscoper/src/Trial.cpp
+++ b/libautoscoper/src/Trial.cpp
@@ -158,7 +158,7 @@ namespace xromm
   }
 
   std::string Trial::toRelativePath(const std::string& path, const std::string& basePath) {
-    return fs::relative(path, basePath);
+    return fs::relative(path, basePath).string();
   }
 
   void Trial::parse(std::ifstream& file,


### PR DESCRIPTION
* `Trial.cpp(161,5): error C2440: 'return': cannot convert from 'std::filesystem::path' to 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>'`
* Regression was initially introduced in 6f86beb56b31295b4c30c837a818818b021de4ee
* For future reference: [C2440](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2440?view=msvc-170&f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(C2440)%26rd%3Dtrue)