### PR TITLE
BUG: Fix reading of .cfg file with CRLF line endings on Linux and macOS

### DIFF
--- a/libautoscoper/src/Trial.cpp
+++ b/libautoscoper/src/Trial.cpp
@@ -183,26 +183,32 @@ namespace xromm
       std::getline(lineStream, key, ' ');
       if (key.compare("mayaCam_csv") == 0) {
         std::getline(lineStream, value);
+        trimLineEndings(value);
         mayaCams.push_back(value);
       }
       else if (key.compare("CameraRootDir") == 0) {
         std::getline(lineStream, value);
+        trimLineEndings(value);
         camRootDirs.push_back(value);
       }
       else if (key.compare("VolumeFile") == 0) {
         std::getline(lineStream, value);
+        trimLineEndings(value);
         volumeFiles.push_back(value);
       }
       else if (key.compare("VolumeFlip") == 0) {
         std::getline(lineStream, value);
+        trimLineEndings(value);
         volumeFlips.push_back(value);
       }
       else if (key.compare("VoxelSize") == 0) {
         std::getline(lineStream, value);
+        trimLineEndings(value);
         voxelSizes.push_back(value);
       }
       else if (key.compare("RenderResolution") == 0) {
         std::getline(lineStream, value);
+        trimLineEndings(value);
         renderResolution.push_back(value);
       }
       else if (key.compare("OptimizationOffsets") == 0) {
@@ -211,6 +217,7 @@ namespace xromm
       }
       else if (key.compare("Version") == 0) {
         std::getline(lineStream, value);
+        trimLineEndings(value);
         parseVersion(value, version);
         continue;
       }
@@ -224,6 +231,11 @@ namespace xromm
       std::getline(versionStream, versionNumber, '.');
       version[idx] = std::atoi(versionNumber.c_str());
     }
+  }
+
+  void Trial::trimLineEndings(std::string& str) {
+    str.erase(std::remove(str.begin(), str.end(), '\r'), str.end());
+    str.erase(std::remove(str.begin(), str.end(), '\n'), str.end());
   }
 
   void  Trial::validate(const std::vector<std::string>& mayaCams,

--- a/libautoscoper/src/Trial.hpp
+++ b/libautoscoper/src/Trial.hpp
@@ -110,6 +110,9 @@ private:
 
     void parseVersion(const std::string& text, std::vector<int>& version);
 
+    // Trim line endings from a string
+    void trimLineEndings(std::string& str);
+
     void convertToAbsolutePaths(std::vector<std::string>& paths, const std::string& basePath);
     std::string toAbsolutePath(const std::string& path, const std::string& basePath);
 


### PR DESCRIPTION
Introduce `trimLineEndings()` function to remove both `\r` and `\n` characters from string. This ensures correct reading of values from .cfg files having `CRLF` line endings.

Note that given the size of the files, introducing a function like `safeGetline()` used in `Camera.cpp` would not significantly improve performance.

For comparison, here are timings for reading random strings of max 1000 characters with uniformly distributed lines endings:

| | trimLineEndings | safeGetline |
|--|--|--|
| 10000 lines (4.8M) | 66625 microseconds | 29825 microseconds |
| 100000 lines (48M)|  556135 microseconds | 266805 microseconds |
| 1000000 lines (~480M) | 5522480 microseconds | 2597533 microseconds| 