### PR TITLE
BUG: Fix reading of .cfg file with backslash on Linux and Windows

### DIFF
--- a/libautoscoper/src/Trial.cpp
+++ b/libautoscoper/src/Trial.cpp
@@ -136,6 +136,26 @@ namespace xromm
     loadRenderResolution(renderResolution);
   }
 
+  void Trial::convertToUnixSlashes(std::string& path) {
+    std::replace(path.begin(), path.end(), '\\', '/');
+    std::string doubleSlash = "//";
+    std::string singleSlash = "/";
+
+    size_t pos = 0;
+    while ((pos = path.find(doubleSlash, pos)) != std::string::npos) {
+        path.replace(pos, doubleSlash.length(), singleSlash);
+        pos += singleSlash.length();
+    }
+
+    // remove trailing slash if the path is more than a single /
+    if (path.size() > 1 && path.back() == '/') {
+        // if it is c:/ then do not remove the trailing slash
+        if (!(path.size() == 3 && path[1] == ':')) {
+            path.pop_back();
+        }
+    }
+  }
+
   void Trial::convertToAbsolutePaths(std::vector<std::string>& paths, const std::string& basePath) {
     for (size_t idx = 0; idx < paths.size(); ++idx) {
       paths[idx] = toAbsolutePath(paths[idx], basePath);
@@ -184,16 +204,19 @@ namespace xromm
       if (key.compare("mayaCam_csv") == 0) {
         std::getline(lineStream, value);
         trimLineEndings(value);
+        convertToUnixSlashes(value);
         mayaCams.push_back(value);
       }
       else if (key.compare("CameraRootDir") == 0) {
         std::getline(lineStream, value);
         trimLineEndings(value);
+        convertToUnixSlashes(value);
         camRootDirs.push_back(value);
       }
       else if (key.compare("VolumeFile") == 0) {
         std::getline(lineStream, value);
         trimLineEndings(value);
+        convertToUnixSlashes(value);
         volumeFiles.push_back(value);
       }
       else if (key.compare("VolumeFlip") == 0) {

--- a/libautoscoper/src/Trial.hpp
+++ b/libautoscoper/src/Trial.hpp
@@ -113,6 +113,10 @@ private:
     // Trim line endings from a string
     void trimLineEndings(std::string& str);
 
+    // Convert to path to Unix slashes and remove trailing slash if
+    // the path is more than a single /
+    static void convertToUnixSlashes(std::string& path);
+
     void convertToAbsolutePaths(std::vector<std::string>& paths, const std::string& basePath);
     std::string toAbsolutePath(const std::string& path, const std::string& basePath);
 


### PR DESCRIPTION
Add the function `convertToUnixSlashes()` to systematically convert values associated with `mayaCam_csv`, `CameraRootDir` and `VolumeFile` keys to paths with Unix slashes that are supported on both Unix and Windows.

Approach was adapted from similar function found in `kwsys/SystemTools.cxx`[^1]

[^1]: https://gitlab.kitware.com/utils/kwsys/-/blob/c9f0da473ac2c21b25c1819141c4828dd238b4d3/SystemTools.cxx#L2125