### PR TITLE
ENH: Update PyAutoscoper required python from 3.6 to 3.8

### DIFF
--- a/scripts/python/pyproject.toml
+++ b/scripts/python/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     {name = "Anthony J. Lombardi", email = "anthony.lombardi@kitware.com" }
 ]
 license = { text = "Autoscoper License" }
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 keywords = []
 classifiers = []
 dependencies = []
@@ -28,7 +28,7 @@ dev = [
 
 [tool.black]
 line-length = 120
-target_version = ['py36']
+target_version = ['py38']
 include = '\.pyi?$'
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Both Python 3.6 and 3.7 reached "end of life"

Latest release by Python version are the following:
* 3.6: 03 Sep 2021
* 3.7: 05 Jun 2023

See https://devguide.python.org/versions/