### PR TITLE
COMP: Pass OpenGL_GL_PREFERENCE to GLEW project

### DIFF
--- a/Superbuild/External_GLEW.cmake
+++ b/Superbuild/External_GLEW.cmake
@@ -23,6 +23,18 @@ if(NOT DEFINED GLEW_DIR AND NOT Autoscoper_USE_SYSTEM_${proj})
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 
+  if(UNIX AND NOT APPLE)
+    if(NOT DEFINED OpenGL_GL_PREFERENCE)
+      set(OpenGL_GL_PREFERENCE "LEGACY")
+    endif()
+    if(NOT "${OpenGL_GL_PREFERENCE}" MATCHES "^(LEGACY|GLVND)$")
+      message(FATAL_ERROR "OpenGL_GL_PREFERENCE variable is expected to be set to LEGACY or GLVND")
+    endif()
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DOpenGL_GL_PREFERENCE:STRING=${OpenGL_GL_PREFERENCE}
+      )
+  endif()
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY https://github.com/BrownBiomechanics/glew.git


### PR DESCRIPTION
This is a follow-up of 60b3d6ec0 (`COMP: Initialize OpenGL_GL_PREFERENCE and pass if down to inner-build`) to Address the following warning:

```
[  7%] Performing configure step for 'GLEW'
loading initial cache file /work/Preview/S-0-E-b/SlicerAutoscoperM-build/Autoscoper-build/GLEW-prefix/tmp/GLEW-cache-Release.cmake CMake Warning (dev) at /usr/share/cmake-3.22/Modules/FindOpenGL.cmake:315 (message):
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  FindOpenGL found both a legacy GL library:

    OPENGL_gl_LIBRARY: /usr/lib64/libGL.so

  and GLVND libraries for OpenGL and GLX:

    OPENGL_opengl_LIBRARY: /usr/lib64/libOpenGL.so
    OPENGL_glx_LIBRARY: /usr/lib64/libGLX.so

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
  compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
  CMakeLists.txt:43 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```