### PR TITLE
Fix errors with RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,3 +3,8 @@ version: 2
 python:
   install:
     - requirements: Documentation/requirements.txt
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,6 +3,6 @@ myst-parser
 sphinx
 sphinx-issues
 sphinx-notfound-page
-sphinx-rtd-theme
+sphinx-rtd-theme == 1.0.0rc1
 sphinxcontrib-autoprogram
 sphinxcontrib-bibtex


### PR DESCRIPTION
From RTD build [21745032](https://readthedocs.org/projects/autoscoper/builds/21745032/):
```
Error
The configuration key "build.os" is required to build your documentation. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
```

From RTD build [21745423](https://readthedocs.org/projects/autoscoper/builds/21745423/):
```
Running Sphinx v7.2.4

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/autoscoper/envs/200/lib/python3.10/site-packages/sphinx/cmd/build.py", line 293, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/autoscoper/envs/200/lib/python3.10/site-packages/sphinx/application.py", line 233, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/autoscoper/envs/200/lib/python3.10/site-packages/sphinx/application.py", line 406, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/autoscoper/envs/200/lib/python3.10/site-packages/sphinx/registry.py", line 460, in load_extension
    metadata = setup(app)
  File "/home/docs/checkouts/readthedocs.org/user_builds/autoscoper/envs/200/lib/python3.10/site-packages/notfound/extension.py", line 337, in setup
    from sphinx.builders.html import setup_js_tag_helper
ImportError: cannot import name 'setup_js_tag_helper' from 'sphinx.builders.html' (/home/docs/checkouts/readthedocs.org/user_builds/autoscoper/envs/200/lib/python3.10/site-packages/sphinx/builders/html/__init__.py)

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/autoscoper/envs/200/lib/python3.10/site-packages/notfound/extension.py", line 337, in setup
    from sphinx.builders.html import setup_js_tag_helper
ImportError: cannot import name 'setup_js_tag_helper' from 'sphinx.builders.html' (/home/docs/checkouts/readthedocs.org/user_builds/autoscoper/envs/200/lib/python3.10/site-packages/sphinx/builders/html/__init__.py)
The full traceback has been saved in /tmp/sphinx-err-x_aeh0nv.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

This was caused by the `sphinx-notfound-page` package being broken on `Sphinx 7.2.0+` , see https://github.com/readthedocs/sphinx-notfound-page/issues/219