### PR TITLE
ENH: Update rtd config to minimum required ahead of cutoff

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,15 @@
 version: 2
 
-python:
-  install:
-    - requirements: Documentation/requirements.txt
-
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
+
+sphinx:
+  builder: html
+  configuration: Documentation/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - requirements: Documentation/requirements.txt


### PR DESCRIPTION
* As of `2023-25-09` RTD will be failing builds that don't contain a `.readthedocs.yaml` config file as described [here](https://docs.readthedocs.io/en/stable/config-file/v2.html#id1).
* See the [migration guide](https://blog.readthedocs.com/migrate-configuration-v2/) for more information