### PR TITLE
BUG: Fix incorrect conversion from viewport coordinates in tracker

### DIFF
--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -599,9 +599,14 @@ std::vector <double> Tracker::trackFrame(unsigned int volumeID, double* xyzypr) 
       double viewport[4];
       this->calculate_viewport(modelview, viewport);
 
-      // Calculate the size of the image to render
-      unsigned render_width = viewport[2] * trial_.render_width / views_[i]->camera()->viewport()[2];
-      unsigned render_height = viewport[3] * trial_.render_height / views_[i]->camera()->viewport()[3];
+      // Calculate the size of the image to render based on the viewport
+      // For more information, see https://github.com/BrownBiomechanics/Autoscoper/issues/203
+      unsigned render_width = (trial_.render_width * (viewport[2] + 1)) / 2;
+      unsigned render_height = (trial_.render_height * (viewport[3] + 1)) / 2;
+
+      if (render_width > trial_.render_width || render_height > trial_.render_height) {
+        throw std::runtime_error("Tracker::trackFrame(): Rendered image is larger than the viewport buffer!\n" + std::to_string(render_width) + " > " + std::to_string(trial_.render_width) + " || " + std::to_string(render_height) + " > " + std::to_string(trial_.render_height));
+      }
 
       // Set the viewports
       views_[i]->drrRenderer(volumeID)->setViewport(viewport[0], viewport[1],


### PR DESCRIPTION
* Closes #203 
* See https://github.com/BrownBiomechanics/Autoscoper/issues/203#issuecomment-1708834168 for the reasoning behind the changes.