### PR TITLE
Tweak naming convention for camera in cfg docs

### DIFF
--- a/Documentation/file-specifications/config.md
+++ b/Documentation/file-specifications/config.md
@@ -16,7 +16,7 @@ The configuration file is a CFG file that contains all of the information to loa
 | `VolumeFile` | The path to the volume file. |
 | `VolumeFlip` | The flip of the volume. |
 | `VoxelSize` | The voxel size of the volume. |
-| `RenderingResolution` | The resolution of the 2D rendering. |
+| `RenderResolution` | The resolution of the 2D rendering. |
 | `OptimizationOffsets` | The offsets for the optimization. |
 
 ### Example
@@ -67,7 +67,7 @@ VolumeFile VolumeImages/radius.tif
 VolumeFlip 0 0 0
 VoxelSize 0.1 0.1 0.1
 
-RenderingResolution 512 512
+RenderResolution 512 512
 
 OptimizationOffsets 0.1 0.1 0.1 0.1 0.1 0.1
 ```
@@ -91,7 +91,7 @@ The configuration file is a CFG file that contains all of the information to loa
 | `VolumeFile` | The path to the volume file. |
 | `VolumeFlip` | The flip of the volume. |
 | `VoxelSize` | The voxel size of the volume. |
-| `RenderingResolution` | The resolution of the 2D rendering. |
+| `RenderResolution` | The resolution of the 2D rendering. |
 | `OptimizationOffsets` | The offsets for the optimization. |
 
 
@@ -110,7 +110,7 @@ VolumeFile C:/Users/username/Documents/Autoscoper/VolumeImages/radius.tif
 VolumeFlip 0 0 0
 VoxelSize 0.1 0.1 0.1
 
-RenderingResolution 512 512
+RenderResolution 512 512
 
 OptimizationOffsets 0.1 0.1 0.1 0.1 0.1 0.1
 ```

--- a/Documentation/file-specifications/config.md
+++ b/Documentation/file-specifications/config.md
@@ -39,7 +39,7 @@ Main Directory
 │       ├───0002.tif
 │       ├───...
 │       └───n.tif
-├───VolumeImages
+├───Volumes
 │   └───radius.tif
 └───{task prefix}.cfg
 ```
@@ -63,7 +63,7 @@ mayaCam_csv Calibration/{task prefix}-cam02.csv
 CameraRootDir RadiographImages/{task prefix}-cam01/
 CameraRootDir RadiographImages/{task prefix}-cam02/
 
-VolumeFile VolumeImages/radius.tif
+VolumeFile Volumes/radius.tif
 VolumeFlip 0 0 0
 VoxelSize 0.1 0.1 0.1
 
@@ -106,7 +106,7 @@ mayaCam_csv C:/Users/username/Documents/Autoscoper/Calibration/{task prefix}-cam
 CameraRootDir C:/Users/username/Documents/Autoscoper/RadiographImages/{task prefix}-cam01/
 CameraRootDir C:/Users/username/Documents/Autoscoper/RadiographImages/{task prefix}-cam02/
 
-VolumeFile C:/Users/username/Documents/Autoscoper/VolumeImages/radius.tif
+VolumeFile C:/Users/username/Documents/Autoscoper/Volumes/radius.tif
 VolumeFlip 0 0 0
 VoxelSize 0.1 0.1 0.1
 

--- a/Documentation/file-specifications/config.md
+++ b/Documentation/file-specifications/config.md
@@ -26,22 +26,22 @@ Given a directory structure like this:
 ```
 Main Directory
 ├───Calibration
-│   ├───cam01.csv
-│   └───cam02.csv
+│   ├───{task prefix}-cam01.csv
+│   └───{task prefix}-cam02.csv
 ├───RadiographImages
-│   ├───cam01
+│   ├───{task prefix}-cam01
 │   │   ├───0001.tif
 │   │   ├───0002.tif
 │   │   ├───...
 │   │   └───n.tif
-│   └───cam02
+│   └───{task prefix}-cam02
 │       ├───0001.tif
 │       ├───0002.tif
 │       ├───...
 │       └───n.tif
 ├───VolumeImages
 │   └───radius.tif
-└───config.cfg
+└───{task prefix}.cfg
 ```
 
 The config file would be placed in the `Main Directory` and would look like this:
@@ -57,11 +57,11 @@ Any relative paths that are in the format `/path/to/something/` will fail to loa
 # This is a comment
 Version 1.1
 
-mayaCam_csv Calibration/cam01.csv
-mayaCam_csv Calibration/cam02.csv
+mayaCam_csv Calibration/{task prefix}-cam01.csv
+mayaCam_csv Calibration/{task prefix}-cam02.csv
 
-CameraRootDir RadiographImages/cam01/
-CameraRootDir RadiographImages/cam02/
+CameraRootDir RadiographImages/{task prefix}-cam01/
+CameraRootDir RadiographImages/{task prefix}-cam02/
 
 VolumeFile VolumeImages/radius.tif
 VolumeFlip 0 0 0
@@ -100,11 +100,11 @@ The configuration file is a CFG file that contains all of the information to loa
 
 ```
 # This is a comment
-mayaCam_csv C:/Users/username/Documents/Autoscoper/Calibration/cam01.csv
-mayaCam_csv C:/Users/username/Documents/Autoscoper/Calibration/cam02.csv
+mayaCam_csv C:/Users/username/Documents/Autoscoper/Calibration/{task prefix}-cam01.csv
+mayaCam_csv C:/Users/username/Documents/Autoscoper/Calibration/{task prefix}-cam02.csv
 
-CameraRootDir C:/Users/username/Documents/Autoscoper/RadiographImages/cam01/
-CameraRootDir C:/Users/username/Documents/Autoscoper/RadiographImages/cam02/
+CameraRootDir C:/Users/username/Documents/Autoscoper/RadiographImages/{task prefix}-cam01/
+CameraRootDir C:/Users/username/Documents/Autoscoper/RadiographImages/{task prefix}-cam02/
 
 VolumeFile C:/Users/username/Documents/Autoscoper/VolumeImages/radius.tif
 VolumeFlip 0 0 0


### PR DESCRIPTION
* Closes #207 
* Update the config file specs
    * Changes references to `camN` to `{task prefix}-camN`
    * Changes config file name from `config.cfg` to `{task prefix}.cfg` 
* See [updated](https://autoscoper--208.org.readthedocs.build/en/208/file-specifications/config.html) documentation page preview. 