### PR TITLE
Add option to enable/disable a single DRR

### DIFF
--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -33,6 +33,7 @@ set(autoscoper_FORMS_HEADERS
   src/ui/VolumeDockWidget.h
   src/ui/WorldViewWindow.h
   src/ui/VolumeBox.h
+  src/ui/VolumeListWidgetItem.h
   src/net/Socket.h
   src/ui/AboutAutoscoper.h
 )
@@ -62,6 +63,7 @@ set(autoscoper_FORMS_SOURCES
   src/ui/WorldViewWindow.cpp
   src/ui/VolumeDockWidget.cpp
   src/ui/VolumeBox.cpp
+  src/ui/VolumeListWidgetItem.cpp
   src/net/Socket.cpp
 )
 

--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -594,7 +594,7 @@ void AutoscoperMainWindow::setupUI()
   //Add Volumes
   for (unsigned int i = 0; i < tracker->trial()->volumes.size(); i++) {
     std::cout << "Volume Name: " << tracker->trial()->volumes[i].name() << std::endl;
-    volumes_widget->addVolume(tracker->trial()->volumes[i].name());
+    volumes_widget->addVolume(tracker->trial()->volumes[i].name(), i);
   }
 
     //Add the new cameras

--- a/autoscoper/src/ui/VolumeDockWidget.cpp
+++ b/autoscoper/src/ui/VolumeDockWidget.cpp
@@ -5,9 +5,11 @@
 #include "ui_VolumeDockWidget.h"
 #include "ui/VolumeDockWidget.h"
 #include "ui/AutoscoperMainWindow.h"
+#include "ui/VolumeListWidgetItem.h"
 
 #include "Tracker.hpp"
 #include "Trial.hpp"
+#include "View.hpp"
 
 #include <QFileInfo>
 
@@ -42,12 +44,15 @@ void VolumeDockWidget::clearVol(){
   n = dock->listWidget->count();*/
 }
 
-void VolumeDockWidget::addVolume(const std::string& filename){
-  QListWidgetItem* volumeItem = new QListWidgetItem();
+void VolumeDockWidget::addVolume(const std::string& filename, int idx){
   QFileInfo fi (QString::fromStdString(filename));
 
-  volumeItem->setText(fi.completeBaseName());
+  std::vector<xromm::gpu::RayCaster*> renderers = {};
+  for (xromm::gpu::View *view : mainwindow->getTracker()->views()) {
+    renderers.push_back(view->drrRenderer(idx));
+  }
 
+  QListWidgetItem* volumeItem = new VolumeListWidgetItem(dock->listWidget, fi.completeBaseName() ,mainwindow, &renderers);
   dock->listWidget->addItem(volumeItem);
   dock->listWidget->setCurrentItem(volumeItem);
 

--- a/autoscoper/src/ui/VolumeDockWidget.h
+++ b/autoscoper/src/ui/VolumeDockWidget.h
@@ -22,7 +22,7 @@ class VolumeDockWidget : public QDockWidget{
     AutoscoperMainWindow * getMainWindow(){return mainwindow;};
 
     void clearVol();
-    void addVolume(const std::string& filename);
+    void addVolume(const std::string& filename, int idx);
 
 
     QString getVolumeName(int volume_index);

--- a/autoscoper/src/ui/VolumeListWidgetItem.cpp
+++ b/autoscoper/src/ui/VolumeListWidgetItem.cpp
@@ -1,0 +1,48 @@
+#include "ui/VolumeListWidgetItem.h"
+#include "ui/AutoscoperMainWindow.h"
+
+#include <QCheckBox>
+#include <QDockWidget>
+#include <QLabel>
+#include <QGridLayout>
+#include <QSpacerItem>
+
+#if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
+#include <gpu/cuda/RayCaster.hpp>
+#elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
+#include <gpu/opencl/RayCaster.hpp>
+#endif
+
+VolumeListWidgetItem::VolumeListWidgetItem(QListWidget* listWidget,const QString& name, AutoscoperMainWindow* main_window, std::vector< xromm::gpu::RayCaster*>* renderers) : QListWidgetItem(listWidget) {
+  this->name_ = name;
+  this->main_window_ = main_window;
+  for (xromm::gpu::RayCaster* renderer : *renderers) {
+    renderers_.push_back(renderer);
+  }
+  setup(listWidget);
+}
+
+void VolumeListWidgetItem::setup(QListWidget* listWidget) {
+  // add a layout
+  QFrame* pFrame = new QFrame(listWidget);
+  pFrame->setMinimumHeight(32);
+  QGridLayout* pLayout = new QGridLayout(pFrame);
+  pLayout->addWidget(new QLabel(name_), 0, 1);
+  visibilityCheckBox_ = new QCheckBox();
+  visibilityCheckBox_->setChecked(true);
+  pLayout->addWidget(visibilityCheckBox_, 0, 0);
+  pLayout->addItem(new QSpacerItem(1, 1, QSizePolicy::Expanding, QSizePolicy::Minimum), 0, 2);
+  pLayout->setMargin(5);
+  pFrame->setLayout(pLayout);
+  listWidget->setItemWidget(this, pFrame);
+  QObject::connect(visibilityCheckBox_, SIGNAL(toggled(bool)), this, SLOT(on_visiblilityCheckBox__toggled(bool)));
+}
+
+void VolumeListWidgetItem::on_visiblilityCheckBox__toggled(bool checked) {
+  if (renderers_.size() > 0) {
+    for (xromm::gpu::RayCaster* renderer : renderers_) {
+      renderer->setVisible(checked);
+    }
+  }
+  main_window_->volume_changed(); // update the volume
+}

--- a/autoscoper/src/ui/VolumeListWidgetItem.h
+++ b/autoscoper/src/ui/VolumeListWidgetItem.h
@@ -1,0 +1,30 @@
+#ifndef VOLUMELISTWIDGETITEM_H
+#define VOLUMELISTWIDGETITEM_H
+
+#include <QListWidgetItem>
+#include <QObject>
+
+class AutoscoperMainWindow;
+class QCheckBox;
+namespace xromm {
+  namespace gpu {
+    class RayCaster;
+  }
+}
+
+class VolumeListWidgetItem : public QObject, public QListWidgetItem {
+  // List Object to display the volume name and a checkbox to toggle visibility
+  Q_OBJECT
+public:
+  VolumeListWidgetItem(QListWidget* listWidget, const QString& name, AutoscoperMainWindow* main_window, std::vector< xromm::gpu::RayCaster*>* renderers);
+private:
+  std::vector< xromm::gpu::RayCaster*> renderers_;
+  QCheckBox *visibilityCheckBox_;
+  QString name_;
+  AutoscoperMainWindow*  main_window_;
+
+  void setup(QListWidget* listWidget);
+public slots:
+  void on_visiblilityCheckBox__toggled(bool checked);
+};
+#endif // !VOLUMELISTWIDGETITEM_H

--- a/autoscoper/src/ui/ui-files/VolumeDockWidget.ui
+++ b/autoscoper/src/ui/ui-files/VolumeDockWidget.ui
@@ -13,7 +13,7 @@
   <property name="minimumSize">
    <size>
     <width>250</width>
-    <height>137</height>
+    <height>209</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/libautoscoper/src/gpu/opencl/RayCaster.cpp
+++ b/libautoscoper/src/gpu/opencl/RayCaster.cpp
@@ -74,6 +74,7 @@ RayCaster::RayCaster() : volumeDescription_(0),
 
   b_viewport_ = new Buffer(4*sizeof(float), CL_MEM_READ_ONLY);
   b_viewport_->read(viewport_);
+  visible_ = true;
 }
 
 RayCaster::~RayCaster()
@@ -159,6 +160,11 @@ RayCaster::render(const Buffer* buffer, unsigned width, unsigned height)
         std::cerr << "RayCaster: WARNING: No volume loaded." << std::endl;
         return;
     }
+
+  if (!visible_) {
+    buffer->fill((char)0x00);
+    return;
+  }
 
   Kernel* kernel = raycaster_program_.compile(
                   RayCaster_cl, "volume_render_kernel");

--- a/libautoscoper/src/gpu/opencl/RayCaster.hpp
+++ b/libautoscoper/src/gpu/opencl/RayCaster.hpp
@@ -60,6 +60,10 @@ public:
     void setViewport(float x, float y, float width, float height);
     void render(const Buffer* buffer, unsigned width, unsigned height);
 
+    void setVisible(bool visible) {
+        visible_ = visible;
+    }
+
     float getSampleDistance() const {
         return sampleDistance_;
     }
@@ -109,6 +113,7 @@ private:
     float rayIntensity_;
     float cutoff_;
     std::string name_;
+    bool visible_;
 };
 
 } } // namespace xromm::opencl


### PR DESCRIPTION
* Closes #206 
* Adds a toggle to each volume to allow the user to switch on and off which volumes are being displayed.
    * Note: If a volume is toggled off, it will be disabled visually and during any optimizations. 
![toggle-drrs](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/48e75a52-f9e9-492d-9c3a-08008bd877c3)

- [ ] Fix this UI bug
![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/ecdb08b6-fce0-4833-a7c3-249efd681918)
