### PR TITLE
Save/load trial improvements

### DIFF
--- a/libautoscoper/src/Trial.cpp
+++ b/libautoscoper/src/Trial.cpp
@@ -88,6 +88,8 @@ namespace xromm
     std::vector<std::string> volumeFlips;
     std::vector<std::string> renderResolution;
     std::vector<std::string> optimizationOffsets;
+    std::string trackingFolder = "Tracking";
+    std::string filterFolder = "xParameters";
 
     parse(file,
           version,
@@ -97,7 +99,9 @@ namespace xromm
           voxelSizes,
           volumeFlips,
           renderResolution,
-          optimizationOffsets);
+          optimizationOffsets,
+          trackingFolder,
+          filterFolder);
 
     file.close();
 
@@ -118,6 +122,9 @@ namespace xromm
       convertToAbsolutePaths(camRootDirs, configLocation);
       convertToAbsolutePaths(volumeFiles, configLocation);
     }
+
+    tracking_folder = trackingFolder;
+    filter_folder = filterFolder;
 
     validate(mayaCams,
              camRootDirs,
@@ -189,7 +196,9 @@ namespace xromm
                     std::vector<std::string>& voxelSizes,
                     std::vector<std::string>& volumeFlips,
                     std::vector<std::string>& renderResolution,
-                    std::vector<std::string>& optimizationOffsets) {
+                    std::vector<std::string>& optimizationOffsets,
+                    std::string& trackingFolder,
+                    std::string& filterFolder) {
 
     std::string line, key, value;
     while (std::getline(file, line)) {
@@ -243,6 +252,19 @@ namespace xromm
         trimLineEndings(value);
         parseVersion(value, version);
         continue;
+      }
+      else if (key.compare("TrackingFolder") == 0) {
+        std::getline(lineStream, value);
+        trimLineEndings(value);
+        trackingFolder = value;
+      }
+      else if (key.compare("FilterFolder") == 0) {
+        std::getline(lineStream, value);
+        trimLineEndings(value);
+        filterFolder = value;
+      }
+      else {
+        std::cout << "Unknown key: " << key << std::endl;
       }
     }
   }

--- a/libautoscoper/src/Trial.cpp
+++ b/libautoscoper/src/Trial.cpp
@@ -422,6 +422,10 @@ namespace xromm
 
     file << "Version 1.1" << std::endl;
 
+    file << "FilterFolder " << filter_folder << std::endl;
+
+    file << "TrackingFolder " << tracking_folder << std::endl;
+
     for (const std::string& mayaCamsFile: mayaCamsFiles) {
       file << "mayaCam_csv " << mayaCamsFile << std::endl;
     }

--- a/libautoscoper/src/Trial.hpp
+++ b/libautoscoper/src/Trial.hpp
@@ -86,6 +86,10 @@ public:
     int render_width;
     int render_height;
 
+    // Trial file info
+    std::string filter_folder;
+    std::string tracking_folder;
+
   KeyCurve * getXCurve(int volumeID);
   KeyCurve * getYCurve(int volumeID);
   KeyCurve * getZCurve(int volumeID);
@@ -106,7 +110,9 @@ private:
                std::vector<std::string>& voxelSizes,
                std::vector<std::string>& volumeFlips,
                std::vector<std::string>& renderResolution,
-               std::vector<std::string>& optimizationOffsets);
+               std::vector<std::string>& optimizationOffsets,
+               std::string& trackingFolder,
+               std::string& filterFolder);
 
     void parseVersion(const std::string& text, std::vector<int>& version);
 


### PR DESCRIPTION
* Adds Two new optional keywords to the trial loader
     * `TrackingFolder` -> Specifies the folder containing the tracking `.tra` files
         * Defaults to `Tracking` if the keyword is not present
     * `FilterFolder` -> Specifies the folder containing the filter `.vie` files
         * Defaults to `xParameters` if the keyword is not present
* Adds support for loading multiple filter files (ie. one for each camera)    
* Closes #150 

```
Version 1.1

TrackingFolder MyTrackingFolder
FilterFolder MyFilterFolder

# The normal CFG file would continue here
```

# TODO

- [ ] Sync filter files with name of camera -> similar to what is done with tracking files
- [ ] Update the trial creator in the UI to allow for the specification of the tracking/filter dirs
- [ ] When `Crtl+S` is hit save everything rather than just the tracking
    - Since loading a trial loads everything I think it makes sense to have the save trial save everything
    - Save `.cfg`
    - Save `.vie` for each camera
    - Save `.tra` for each volume
- [ ] `Crtl+Shift+S` will remain `Save as` but again will save everything too