### PR TITLE
ENH: Add setting to switch between viewport logic

### DIFF
--- a/autoscoper/src/net/Socket.cpp
+++ b/autoscoper/src/net/Socket.cpp
@@ -418,9 +418,26 @@ void Socket::handleMessage(QTcpSocket * connection, char* data, qint64 length)
     }
     break;
 
+  case 17:
+    // Toggle between the viewport 2 pixel calculation methods
+  {
+    size_t offset = preamble_offset;
+
+    SocketReadValuePointerMacro(method, qint32); // 0 for old method, 1 for new method
+    this->m_mainwindow->on_actionUse_New_Viewport_Logic_triggered((bool)(*method));
+    std::cout << "Toggled viewport logic to " << *method << std::endl;
+    connection->write(QByteArray(1, 17));
+
+  }
+  break;
+
   default:
     std::cerr << "Cannot handle message" << std::endl;
+    for (int i = 0; i < length; ++i)
+      std::cout << data[i];
+    std::cout << std::endl;
     connection->write(QByteArray(1,0));
+
     break;
   }
 }

--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -1130,6 +1130,7 @@ bool AutoscoperMainWindow::openTrial(QString filename){
   try {
     Trial * trial = new Trial(filename.toStdString().c_str());
     tracker->load(*trial);
+    tracker->SetViewportLogic(this->use_new_viewport_2_pixel_calculations_);
     delete trial;
 
     trial_filename = filename.toStdString().c_str();
@@ -1719,6 +1720,13 @@ void AutoscoperMainWindow::on_actionLoad_xml_batch_triggered(bool checked){
     fprintf(stderr,"%s\n",inputfile.toStdString().c_str());
     runBatch(inputfile);
     }
+}
+
+void AutoscoperMainWindow::on_actionUse_New_Viewport_Logic_triggered(bool checked) {
+  this->use_new_viewport_2_pixel_calculations_ = checked;
+  if (tracker != NULL) {
+    tracker->SetViewportLogic(checked);
+  }
 }
 
 

--- a/autoscoper/src/ui/AutoscoperMainWindow.h
+++ b/autoscoper/src/ui/AutoscoperMainWindow.h
@@ -159,6 +159,7 @@ class AutoscoperMainWindow : public QMainWindow{
     Tracker * tracker;
     GLTracker * gltracker;
     QOpenGLContext* shared_glcontext;
+    bool use_new_viewport_2_pixel_calculations_ = false;
 
     //Manipulator
     std::vector <Manip3D *> manipulator;
@@ -222,6 +223,7 @@ class AutoscoperMainWindow : public QMainWindow{
     void on_actionSave_Test_Sequence_triggered(bool checked);
     void on_actionSaveForBatch_triggered(bool checked);
     void on_actionLoad_xml_batch_triggered(bool checked);
+    void on_actionUse_New_Viewport_Logic_triggered(bool checked);
 
     //Edit
     void on_actionUndo_triggered(bool checked);

--- a/autoscoper/src/ui/ui-files/AutoscoperMainWindow.ui
+++ b/autoscoper/src/ui/ui-files/AutoscoperMainWindow.ui
@@ -432,6 +432,8 @@ Dialog</string>
     <addaction name="separator"/>
     <addaction name="actionSave_Test_Sequence"/>
     <addaction name="separator"/>
+    <addaction name="actionUse_New_Viewport_Logic"/>
+    <addaction name="separator"/>
     <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuEdit">
@@ -715,6 +717,14 @@ Dialog</string>
    </property>
    <property name="text">
     <string>Thick Line Mode</string>
+   </property>
+  </action>
+  <action name="actionUse_New_Viewport_Logic">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Use New Viewport Logic</string>
    </property>
   </action>
  </widget>

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -602,6 +602,13 @@ std::vector <double> Tracker::trackFrame(unsigned int volumeID, double* xyzypr) 
       // Calculate the size of the image to render based on the viewport
       unsigned render_width = viewport[2] * trial_.render_width / views_[i]->camera()->viewport()[2];
       unsigned render_height = viewport[3] * trial_.render_height / views_[i]->camera()->viewport()[3];
+      // For more information:
+      // * https://github.com/BrownBiomechanics/Autoscoper/issues/203
+      // * https://github.com/BrownBiomechanics/Autoscoper/pull/211
+      if (this->use_new_viewport_2_pixel_calculations_) {
+        render_width = ((trial_.render_width * (viewport[2] + 1)) / 2) - ((trial_.render_width * (viewport[0] + 1)) / 2); // (width * (max_x + 1)) / 2 - (width * (min_x + 1)) / 2
+        render_height = ((trial_.render_height * (viewport[3] + 1)) / 2) - ((trial_.render_height * (viewport[1] + 1)) / 2); // (height * (max_y + 1)) / 2 - (height * (min_y + 1)) / 2
+      }
 
       if (render_width > trial_.render_width || render_height > trial_.render_height) {
         throw std::runtime_error("Tracker::trackFrame(): Rendered image is larger than the viewport buffer!\n" + std::to_string(render_width) + " > " + std::to_string(trial_.render_width) + " || " + std::to_string(render_height) + " > " + std::to_string(trial_.render_height));

--- a/libautoscoper/src/Tracker.hpp
+++ b/libautoscoper/src/Tracker.hpp
@@ -101,6 +101,7 @@ namespace xromm
     //std::vector<double> trackImplantFrame(unsigned int volumeID, double * xyzypr) const;
 
     void getFullDRR(unsigned int volumeID) const;
+    void SetViewportLogic(bool use_new);
 
 
   private:
@@ -111,6 +112,7 @@ namespace xromm
     Trial trial_;
     std::vector <gpu::VolumeDescription*> volumeDescription_;
     std::vector <gpu::View*> views_;
+    bool use_new_viewport_2_pixel_calculations_ = false;
 #if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
     Buffer* rendered_drr_;
     Buffer* rendered_rad_;

--- a/scripts/matlab/AutoscoperConnection.m
+++ b/scripts/matlab/AutoscoperConnection.m
@@ -493,5 +493,20 @@ classdef AutoscoperConnection
             ncc_out  = [ncc(1), ncc(2), ncc(1) * ncc(2)];
         end
 
+        function toggleViewportConversionMethod(obj, method)
+            % Toggles the viewport conversion method to either
+            % 0 for the default method
+            % 1 for the new method
+
+            if nargin < 2
+                error('Not enough input arguments');
+            end
+            fwrite(obj.socket_descriptor, [ ...
+                                           17 ...
+                                           typecast(int32(method), 'uint8') ...
+                                          ]);
+
+        end
+
     end
 end

--- a/scripts/python/PyAutoscoper/connect.py
+++ b/scripts/python/PyAutoscoper/connect.py
@@ -594,3 +594,13 @@ class AutoscoperConnection:
         response = self._send_command(0x0F)  # 15
         num_frames = struct.unpack("i", response[1:])[0]
         return num_frames
+
+    def toggleViewportConversionMethod(self, method: bool) -> None:
+        """
+        Toggle the viewport conversion method.
+
+        False for the default method, True for the new method.
+
+        :param method: The viewport conversion method to use.
+        """
+        self._send_command(0x11, int(method))  # 17


### PR DESCRIPTION
* See comment https://github.com/BrownBiomechanics/Autoscoper/issues/203#issuecomment-1768948851
* Adds a new option to toggle between the changes introduced in #204 and the previous code.
    * Defaults to off (ie. previous logic) 
* Adds new function to PyAutoscoper and the MATLAB class
    * `toggleViewportConversionMethod` takes a 0 or 1 for the old and new methods respectively.   
* ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/61c8f90b-bd58-483b-bdbc-ca6b4914400c)
