### PR TITLE
BUG: Fix getRandom() returning values above max limit

### DIFF
--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -38,7 +38,7 @@ void intializeRandom()
 
 float getRandom(float low, float high)
 {
-  return low + (high - low) * getRandomClamped();
+  return low + getRandomClamped() * (high - low);
 }
 
 float getRandomClamped()

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -38,7 +38,7 @@ void intializeRandom()
 
 float getRandom(float low, float high)
 {
-  return low + (high - low + 1.0f)*(float)rand() / (RAND_MAX + 1.0f);
+  return low + (high - low) * getRandomClamped();
 }
 
 float getRandomClamped()


### PR DESCRIPTION
* Closes #217 


| method/`rand()` return val | `0` | `RAND_MAX` |
| --- | ---- | --- |
| Old | `low ` | `≈(high+1)` *| 
| New | `low` | `high` |

*Since, previously, we were scaling by `RAND_MAX/(RAND_MAX+1)` the computed value is going to be extremely close to , but slightly lower, than `high+1`