### PR TITLE
Fix CUDA RayCaster not having setVisible member

### DIFF
--- a/libautoscoper/src/gpu/cuda/RayCaster.cpp
+++ b/libautoscoper/src/gpu/cuda/RayCaster.cpp
@@ -46,6 +46,7 @@
 #include "RayCaster.hpp"
 #include "RayCaster_kernels.h"
 #include "VolumeDescription.hpp"
+#include <cuda_runtime_api.h>
 
 namespace xromm { namespace gpu {
 
@@ -133,6 +134,11 @@ RayCaster::render(float* buffer, size_t width, size_t height)
 {
     if (!volumeDescription_) {
         std::cerr << "RayCaster: WARNING: No volume loaded. " << std::endl;
+        return;
+    }
+
+    if (!visible_) {
+        cudaMemset(buffer, 0, width * height * sizeof(float));
         return;
     }
 

--- a/libautoscoper/src/gpu/cuda/RayCaster.hpp
+++ b/libautoscoper/src/gpu/cuda/RayCaster.hpp
@@ -103,6 +103,9 @@ public:
         name_ = name;
     }
 
+    void setVisible(bool visible) {
+        visible_ = visible;
+    }
 private:
 
     VolumeDescription* volumeDescription_;
@@ -118,6 +121,8 @@ private:
     float cutoff_;
 
     std::string name_;
+
+    bool visible_;
 };
 
 } } // namespace xromm::cuda


### PR DESCRIPTION
* error C2039: 'setVisible': is not a member of 'xromm::gpu::RayCaster'
* Regression introduced in 103df1a