### PR TITLE
PERF: Introduce particle data structure for PSO

### DIFF
--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -21,6 +21,12 @@ Particle::Particle(const std::vector<float>& pos) {
   this->Velocity = std::vector<float>(NUM_OF_DIMENSIONS, 0.f);
 }
 
+Particle::Particle(float start_range_min, float start_range_max) {
+  this->NCC = FLT_MAX;
+  this->Velocity = std::vector<float>(NUM_OF_DIMENSIONS, 0.f);
+  this->initializePosition(start_range_min, start_range_max);
+}
+
 Particle& Particle::operator=(const Particle& p) {
   this->NCC = p.NCC;
   this->Position = p.Position;

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -98,12 +98,7 @@ void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPO
   float OMEGA = 0.8f;
 
   // Make a copy of the particles, this will be the initial pBest
-  std::vector<Particle> pBest;
-  Particle pBestTemp;
-  for (const Particle& p : particles) {
-    pBestTemp = p;
-    pBest.push_back(pBestTemp);
-  }
+  std::vector<Particle> pBest = particles;
 
   // Calc NCC for gBest
   gBest.NCC = host_fitness_function(gBest.Position);
@@ -140,6 +135,7 @@ void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPO
     OMEGA = OMEGA * 0.9f;
 
     std::cout << "Current Best NCC: " << gBest.NCC << std::endl;
+
     //std::cout << "Stall: " << stall_iter << std::endl;
     if (abs(gBest.NCC - currentBest.NCC) < 1e-4f) {
       //std::cout << "Increased Stall Iter" << std::endl;
@@ -148,6 +144,7 @@ void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPO
       //std::cout << "Zeroed Stall Iter" << std::endl;
       stall_iter = 0;
     }
+
     if (stall_iter == MAX_STALL) {
       std::cout << "Maximum Stall Iteration was reached" << std::endl;
       do_this = false;

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -1,5 +1,6 @@
 #include "PSO.hpp"
 #include <iostream>
+#include <cfloat> // For FLT_MAX
 #include <string>
 
 // Particle Struct Function Definitions

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -34,6 +34,25 @@ Particle& Particle::operator=(const Particle& p) {
   return *this;
 }
 
+std::ostream& operator<<(std::ostream& os, const std::vector<float>& values)
+{
+  auto it = std::begin(values);
+  for (auto value: values) {
+    os << value;
+    ++it;
+    os << (it != std::end(values) ? ", " : "");
+    }
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Particle& p)
+{
+  os << "Position: " << p.Position << std::endl;
+  os << "Velocity: " << p.Velocity << std::endl;
+  os << "NCC: " << p.NCC;
+  return os;
+}
+
 void Particle::updateVelocityAndPosition(const Particle& pBest, const Particle& gBest, float omega) {
   for (int dim = 0; dim < NUM_OF_DIMENSIONS; dim++) {
     float rp = getRandomClamped();

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -29,20 +29,21 @@ Particle& Particle::operator=(const Particle& p) {
 }
 
 void Particle::updateVelocityAndPosition(Particle* pBest, Particle* gBest, float omega) {
-  for (int i = 0; i < NUM_OF_DIMENSIONS; i++) {
+  for (int dim = 0; dim < NUM_OF_DIMENSIONS; dim++) {
     float rp = getRandomClamped();
     float rg = getRandomClamped();
 
-    this->Velocity.at(i) =
-        omega * this->Velocity.at(i)
-        + c1 * rp * (pBest->Position.at(i) - this->Position.at(i))
-        + c2 * rg * (gBest->Position.at(i) - this->Position.at(i));
-    this->Position.at(i) += this->Velocity.at(i);
+    this->Velocity.at(dim) =
+        omega * this->Velocity.at(dim)
+        + c1 * rp * (pBest->Position.at(dim) - this->Position.at(dim))
+        + c2 * rg * (gBest->Position.at(dim) - this->Position.at(dim));
+
+    this->Position.at(dim) += this->Velocity.at(dim);
   }
 }
 
 void Particle::initializePosition(float start_range_min, float start_range_max) {
-  for (int i = 0; i < NUM_OF_DIMENSIONS; i++) {
+  for (int dim = 0; dim < NUM_OF_DIMENSIONS; dim++) {
     this->Position.push_back(getRandom(start_range_min, start_range_max));
   }
 }
@@ -50,11 +51,10 @@ void Particle::initializePosition(float start_range_min, float start_range_max) 
 // New Particle Swarm Optimization
 float host_fitness_function(const std::vector<float>& x)
 {
-  double xyzypr_manip[6] = { 0 };
-  for (int i = 0; i <= NUM_OF_DIMENSIONS - 1; i++)
-  {
-    xyzypr_manip[i] = (double)x[i];
-  } // i
+  double xyzypr_manip[6] = { 0.0 };
+  for (int dim = 0; dim <= NUM_OF_DIMENSIONS - 1; dim++) {
+    xyzypr_manip[dim] = (double)x[dim];
+  }
 
   double total = PSO_FUNC(xyzypr_manip);
 
@@ -119,23 +119,22 @@ void pso(std::vector<Particle>* particles, Particle* gBest, unsigned int MAX_EPO
 
     currentBest = *gBest;
 
-    for (int i = 0; i < NUM_OF_PARTICLES; i++)
+    for (int idx = 0; idx < NUM_OF_PARTICLES; idx++)
     {
-
       // Update the velocities and positions
-      particles->at(i).updateVelocityAndPosition(&pBest.at(i), gBest, OMEGA);
+      particles->at(idx).updateVelocityAndPosition(&pBest.at(idx), gBest, OMEGA);
 
       // Get the NCC of the current particle
-      particles->at(i).NCC = host_fitness_function(particles->at(i).Position);
+      particles->at(idx).NCC = host_fitness_function(particles->at(idx).Position);
 
       // Update the pBest if the current particle is better
-      if (particles->at(i).NCC < pBest.at(i).NCC) {
-        pBest.at(i) = particles->at(i);
+      if (particles->at(idx).NCC < pBest.at(idx).NCC) {
+        pBest.at(idx) = particles->at(idx);
       }
 
       // Update the gBest if the current particle is better
-      if (particles->at(i).NCC < gBest->NCC) {
-        *gBest = particles->at(i);
+      if (particles->at(idx).NCC < gBest->NCC) {
+        *gBest = particles->at(idx);
       }
     }
 

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -136,7 +136,7 @@ Particle pso(float start_range_min, float start_range_max, unsigned int MAX_EPOC
     particles[idx] = Particle(start_range_min, start_range_max);
   }
 
-  Particle gBest;
+  Particle gBest = particles[0];
 
   // Make a copy of the particles, this will be the initial pBest
   std::vector<Particle> pBest = particles;

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -12,13 +12,13 @@ Particle::Particle(const Particle& p) {
 
 Particle::Particle() {
   this->NCC = FLT_MAX;
-  this->Velocity = *(new std::vector<float>(NUM_OF_DIMENSIONS, 0.f));
+  this->Velocity = std::vector<float>(NUM_OF_DIMENSIONS, 0.f);
 }
 
 Particle::Particle(const std::vector<float>& pos) {
   this->NCC = FLT_MAX;
   this->Position = pos;
-  this->Velocity = *(new std::vector<float>(NUM_OF_DIMENSIONS, 0.f));
+  this->Velocity = std::vector<float>(NUM_OF_DIMENSIONS, 0.f);
 }
 
 Particle& Particle::operator=(const Particle& p) {

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -12,6 +12,7 @@ Particle::Particle(const Particle& p) {
 
 Particle::Particle() {
   this->NCC = FLT_MAX;
+  this->Position = std::vector<float>(NUM_OF_DIMENSIONS, 0.f);
   this->Velocity = std::vector<float>(NUM_OF_DIMENSIONS, 0.f);
 }
 
@@ -23,6 +24,7 @@ Particle::Particle(const std::vector<float>& pos) {
 
 Particle::Particle(float start_range_min, float start_range_max) {
   this->NCC = FLT_MAX;
+  this->Position = std::vector<float>(NUM_OF_DIMENSIONS, 0.f);
   this->Velocity = std::vector<float>(NUM_OF_DIMENSIONS, 0.f);
   this->initializePosition(start_range_min, start_range_max);
 }
@@ -136,7 +138,7 @@ Particle pso(float start_range_min, float start_range_max, unsigned int MAX_EPOC
     particles[idx] = Particle(start_range_min, start_range_max);
   }
 
-  Particle gBest = particles[0];
+  Particle gBest;
 
   // Make a copy of the particles, this will be the initial pBest
   std::vector<Particle> pBest = particles;

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -52,7 +52,7 @@ void Particle::initializePosition(float start_range_min, float start_range_max) 
 float host_fitness_function(const std::vector<float>& x)
 {
   double xyzypr_manip[NUM_OF_DIMENSIONS] = { 0.0 };
-  for (int dim = 0; dim <= NUM_OF_DIMENSIONS - 1; dim++) {
+  for (int dim = 0; dim < NUM_OF_DIMENSIONS; dim++) {
     xyzypr_manip[dim] = (double)x[dim];
   }
 

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -125,9 +125,6 @@ void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPO
   // Make a copy of the particles, this will be the initial pBest
   std::vector<Particle> pBest = particles;
 
-  // Calc NCC for gBest
-  gBest.NCC = host_fitness_function(gBest.Position);
-
   Particle currentBest;
   while (do_this)
   {

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -112,15 +112,13 @@ void pso(std::vector<Particle>* particles, Particle* gBest, unsigned int MAX_EPO
   while (do_this)
   {
     //std::cout << "OMEGA: " << OMEGA << std::endl;
-    if (counter >= MAX_EPOCHS)
-    {
+    if (counter >= MAX_EPOCHS) {
       do_this = false;
     }
 
     currentBest = *gBest;
+    for (int idx = 0; idx < NUM_OF_PARTICLES; idx++) {
 
-    for (int idx = 0; idx < NUM_OF_PARTICLES; idx++)
-    {
       // Update the velocities and positions
       particles->at(idx).updateVelocityAndPosition(&pBest.at(idx), gBest, OMEGA);
 
@@ -142,17 +140,14 @@ void pso(std::vector<Particle>* particles, Particle* gBest, unsigned int MAX_EPO
 
     std::cout << "Current Best NCC: " << gBest->NCC << std::endl;
     //std::cout << "Stall: " << stall_iter << std::endl;
-    if (abs(gBest->NCC - currentBest.NCC) < 1e-4f)
-    {
+    if (abs(gBest->NCC - currentBest.NCC) < 1e-4f) {
       //std::cout << "Increased Stall Iter" << std::endl;
       stall_iter++;
-    } else if (abs(gBest->NCC - currentBest.NCC) > 0.001f)
-    {
+    } else if (abs(gBest->NCC - currentBest.NCC) > 0.001f) {
       //std::cout << "Zeroed Stall Iter" << std::endl;
       stall_iter = 0;
     }
-    if (stall_iter == MAX_STALL)
-    {
+    if (stall_iter == MAX_STALL) {
       std::cout << "Maximum Stall Iteration was reached" << std::endl;
       do_this = false;
     }

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -48,7 +48,7 @@ void Particle::initializePosition(float start_range_min, float start_range_max) 
 }
 
 // New Particle Swarm Optimization
-float host_fitness_function(std::vector<float> x)
+float host_fitness_function(const std::vector<float>& x)
 {
   double xyzypr_manip[6] = { 0 };
   for (int i = 0; i <= NUM_OF_DIMENSIONS - 1; i++)
@@ -100,7 +100,7 @@ void pso(std::vector<Particle>* particles, Particle* gBest, unsigned int MAX_EPO
   // Make a copy of the particles, this will be the initial pBest
   std::vector<Particle> pBest;
   Particle pBestTemp;
-  for (Particle p : *particles) {
+  for (const Particle& p : *particles) {
     pBestTemp = p;
     pBest.push_back(pBestTemp);
   }

--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -115,12 +115,28 @@ float getRandomClamped()
   return (float)rand() / (float)RAND_MAX;
 }
 
-void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL)
+Particle pso(float start_range_min, float start_range_max, unsigned int MAX_EPOCHS, unsigned int MAX_STALL)
 {
   int stall_iter = 0;
   bool do_this = true;
   unsigned int counter = 0;
   float OMEGA = 0.8f;
+
+  // Pre-allocate particles
+  std::vector<Particle> particles(NUM_OF_PARTICLES);
+
+  // First particle is the initial position
+  particles[0] = Particle({ 0.f, 0.f, 0.f, 0.f, 0.f, 0.f });
+
+  srand((unsigned)time(NULL));
+
+  // ... and the other particles positions are randomly iniialized
+  for (int idx = 1; idx < NUM_OF_PARTICLES; idx++)
+  {
+    particles[idx] = Particle(start_range_min, start_range_max);
+  }
+
+  Particle gBest;
 
   // Make a copy of the particles, this will be the initial pBest
   std::vector<Particle> pBest = particles;
@@ -175,4 +191,6 @@ void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPO
     counter++;
   }
   std::cout << "Total #Epoch of: " << counter << std::endl;
+
+  return gBest;
 }

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -39,8 +39,9 @@ struct Particle {
   Particle(const std::vector<float>& pos);
   // Assignment operator
   Particle& operator=(const Particle& p);
-  void updateVelocityAndPosition(Particle* pBest, Particle* gBest, float omega);
+
+  void updateVelocityAndPosition(const Particle& pBest, const Particle& gBest, float omega);
   void initializePosition(float start_range_min, float start_range_max);
 };
 
-void pso(std::vector<Particle>* particles, Particle* gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);
+void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -37,6 +37,7 @@ struct Particle {
   // Default constructor
   Particle();
   Particle(const std::vector<float>& pos);
+  Particle(float start_range_min, float start_range_max);
   // Assignment operator
   Particle& operator=(const Particle& p);
 

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -25,7 +25,7 @@ void intializeRandom();
 
 float getRandom(float low, float high);
 float getRandomClamped();
-float host_fitness_function(std::vector<float> x);
+float host_fitness_function(const std::vector<float>& x);
 
 struct Particle {
   float NCC;

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <math.h>
+#include <vector>
 const int NUM_OF_PARTICLES = 100;
 const int NUM_OF_DIMENSIONS = 6;
 const float c1 = 1.5f;
@@ -24,6 +25,22 @@ void intializeRandom();
 
 float getRandom(float low, float high);
 float getRandomClamped();
-float host_fitness_function(float x[]);
+float host_fitness_function(std::vector<float> x);
 
-void pso(float *positions, float *velocities, float *pBests, float *gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);
+struct Particle {
+  float ncc_val;
+  std::vector<float> position;
+  std::vector<float> velocity;
+
+  // Copy constructor
+  Particle(const Particle& p);
+  // Default constructor
+  Particle();
+  Particle(const std::vector<float>& pos);
+  // Assignment operator
+  Particle& operator=(const Particle& p);
+  void updateVelocityAndPosition(Particle* pBest, Particle* gBest, float OMEGA);
+  void InitializePosition(float START_RANGE_MIN, float START_RANGE_MAX);
+};
+
+void pso(std::vector<Particle>* particles, Particle* gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <math.h>
+#include <ostream>
 #include <vector>
 const int NUM_OF_PARTICLES = 100;
 const int NUM_OF_DIMENSIONS = 6;
@@ -44,5 +45,9 @@ struct Particle {
   void updateVelocityAndPosition(const Particle& pBest, const Particle& gBest, float omega);
   void initializePosition(float start_range_min, float start_range_max);
 };
+
+// Stream operator
+extern std::ostream& operator<<(std::ostream& os, const std::vector<float>& values);
+extern std::ostream& operator<<(std::ostream& os, const Particle& p);
 
 void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -50,4 +50,4 @@ struct Particle {
 extern std::ostream& operator<<(std::ostream& os, const std::vector<float>& values);
 extern std::ostream& operator<<(std::ostream& os, const Particle& p);
 
-void pso(std::vector<Particle>& particles, Particle& gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);
+Particle pso(float start_range_min, float start_range_max, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);

--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -28,9 +28,9 @@ float getRandomClamped();
 float host_fitness_function(std::vector<float> x);
 
 struct Particle {
-  float ncc_val;
-  std::vector<float> position;
-  std::vector<float> velocity;
+  float NCC;
+  std::vector<float> Position;
+  std::vector<float> Velocity;
 
   // Copy constructor
   Particle(const Particle& p);
@@ -39,8 +39,8 @@ struct Particle {
   Particle(const std::vector<float>& pos);
   // Assignment operator
   Particle& operator=(const Particle& p);
-  void updateVelocityAndPosition(Particle* pBest, Particle* gBest, float OMEGA);
-  void InitializePosition(float START_RANGE_MIN, float START_RANGE_MAX);
+  void updateVelocityAndPosition(Particle* pBest, Particle* gBest, float omega);
+  void initializePosition(float start_range_min, float start_range_max);
 };
 
 void pso(std::vector<Particle>* particles, Particle* gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -419,24 +419,8 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       unsigned int MAX_EPOCHS = max_iter;
       unsigned int MAX_STALL = max_stall_iter;
 
-      // Pre-allocate particles
-      std::vector<Particle> particles(NUM_OF_PARTICLES);
-
-      srand((unsigned)time(NULL));
-
-      // First particle is the initial position
-      particles[0] = Particle({ 0.f, 0.f, 0.f, 0.f, 0.f, 0.f });
-
-      // ... and the other particles positions are randomly iniialized
-      for (int idx = 1; idx < NUM_OF_PARTICLES; idx++)
-      {
-        particles[idx] = Particle(START_RANGE_MIN, START_RANGE_MAX);
-      }
-
-      Particle gBest;
-
       clock_t cpu_begin = clock();
-      pso(particles, gBest, MAX_EPOCHS, MAX_STALL);
+      Particle gBest = pso(START_RANGE_MIN, START_RANGE_MAX, MAX_EPOCHS, MAX_STALL);
       clock_t cpu_end = clock();
 
       printf("Time elapsed:%10.3lf s\n", (double)(cpu_end - cpu_begin) / CLOCKS_PER_SEC);

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -469,15 +469,6 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       trial_.getPitchCurve(-1)->insert(trial_.frame, xyzypr[4]);
       trial_.getRollCurve(-1)->insert(trial_.frame, xyzypr[5]);
 
-
-      // Get Current Pose
-      double xyzypr[6] = { (*trial_.getXCurve(-1))(trial_.frame),
-        (*trial_.getYCurve(-1))(trial_.frame),
-        (*trial_.getZCurve(-1))(trial_.frame),
-        (*trial_.getYawCurve(-1))(trial_.frame),
-        (*trial_.getPitchCurve(-1))(trial_.frame),
-        (*trial_.getRollCurve(-1))(trial_.frame) };
-
       // DOWNHILL SIMPLEX
       // Generate the 7 vertices that form the initial simplex. Because
       // the independent variables of the function we are optimizing over

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -431,7 +431,7 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       for (int i = 0; i < NUM_OF_PARTICLES-1; i++)
       {
         p = Particle();
-        p.InitializePosition(START_RANGE_MIN, START_RANGE_MAX);
+        p.initializePosition(START_RANGE_MIN, START_RANGE_MAX);
         particles.push_back(p);
       }
 
@@ -443,13 +443,13 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
 
       std::cout << "Pose change from initial position: ";
       for (int i = 0; i < NUM_OF_DIMENSIONS-1; i++) {
-        std::cout << gBest.position[i] << ", ";
-        xyzypr_manip[i] = gBest.position[i];
+          std::cout << gBest.Position[i] << ", ";
+          xyzypr_manip[i] = gBest.Position[i];
       }
-      std::cout << gBest.position[NUM_OF_DIMENSIONS-1] << std::endl;
-      xyzypr_manip[NUM_OF_DIMENSIONS-1] = gBest.position[NUM_OF_DIMENSIONS-1];
+      std::cout << gBest.Position[NUM_OF_DIMENSIONS-1] << std::endl;
+      xyzypr_manip[NUM_OF_DIMENSIONS-1] = gBest.Position[NUM_OF_DIMENSIONS-1];
 
-      printf("Minimum NCC from PSO = %f\n", gBest.ncc_val);
+      printf("Minimum NCC from PSO = %f\n", gBest.NCC);
 
       manip = CoordFrame::from_xyzAxis_angle(xyzypr_manip);
       // PSO End

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -430,9 +430,7 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
 
       for (int i = 0; i < NUM_OF_PARTICLES-1; i++)
       {
-        p = Particle();
-        p.initializePosition(START_RANGE_MIN, START_RANGE_MAX);
-        particles.push_back(p);
+        particles.push_back(Particle(START_RANGE_MIN, START_RANGE_MAX));
       }
 
       clock_t cpu_begin = clock();

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -441,13 +441,12 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
 
       printf("Time elapsed:%10.3lf s\n", (double)(cpu_end - cpu_begin) / CLOCKS_PER_SEC);
 
-      std::cout << "Pose change from initial position: ";
-      for (int i = 0; i < NUM_OF_DIMENSIONS-1; i++) {
-          std::cout << gBest.Position[i] << ", ";
-          xyzypr_manip[i] = gBest.Position[i];
+      using ::operator<<; // Access the stream operator from the global namespace
+      std::cout << "Pose change from initial position: " << gBest.Position << std::endl;
+
+      for (int dim = 0; dim < NUM_OF_DIMENSIONS; dim++) {
+          xyzypr_manip[dim] = gBest.Position[dim];
       }
-      std::cout << gBest.Position[NUM_OF_DIMENSIONS-1] << std::endl;
-      xyzypr_manip[NUM_OF_DIMENSIONS-1] = gBest.Position[NUM_OF_DIMENSIONS-1];
 
       printf("Minimum NCC from PSO = %f\n", gBest.NCC);
 

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -409,7 +409,7 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
     if (optimization_method == 0) // 0: PSO + Downhill Simplex, 1: Downhill Simplex
     {
       // PSO Algorithm
-      double xyzypr_manip[6] = { 0 };
+
       //int gBest = 0;
       //int gBestTest = 1000;
       int stall_iter = 0;
@@ -444,11 +444,10 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       using ::operator<<; // Access the stream operator from the global namespace
       std::cout << "Pose change from initial position: " << gBest.Position << std::endl;
 
-      for (int dim = 0; dim < NUM_OF_DIMENSIONS; dim++) {
-          xyzypr_manip[dim] = gBest.Position[dim];
-      }
-
       printf("Minimum NCC from PSO = %f\n", gBest.NCC);
+
+      double xyzypr_manip[NUM_OF_DIMENSIONS] = { 0 };
+      std::copy(gBest.Position.begin(), gBest.Position.begin() + NUM_OF_DIMENSIONS, xyzypr_manip);
 
       manip = CoordFrame::from_xyzAxis_angle(xyzypr_manip);
       // PSO End

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -419,18 +419,20 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       unsigned int MAX_EPOCHS = max_iter;
       unsigned int MAX_STALL = max_stall_iter;
 
-      std::vector<Particle> particles;
-      Particle gBest;
+      // Pre-allocate particles
+      std::vector<Particle> particles(NUM_OF_PARTICLES);
 
       srand((unsigned)time(NULL));
 
-      Particle p({ 0.f, 0.f, 0.f, 0.f, 0.f, 0.f });
-      particles.push_back(p); // First particle is the initial position
-      gBest = p; // gBest is initially the initial position
+      // First particle is the initial position
+      particles[0] = Particle({ 0.f, 0.f, 0.f, 0.f, 0.f, 0.f });
 
-      for (int i = 0; i < NUM_OF_PARTICLES-1; i++)
+      Particle gBest = particles[0];
+
+      // ... and the other particles positions are randomly iniialized
+      for (int idx = 1; idx < NUM_OF_PARTICLES; idx++)
       {
-        particles.push_back(Particle(START_RANGE_MIN, START_RANGE_MAX));
+        particles[idx] = Particle(START_RANGE_MIN, START_RANGE_MAX);
       }
 
       clock_t cpu_begin = clock();

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -427,13 +427,13 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       // First particle is the initial position
       particles[0] = Particle({ 0.f, 0.f, 0.f, 0.f, 0.f, 0.f });
 
-      Particle gBest = particles[0];
-
       // ... and the other particles positions are randomly iniialized
       for (int idx = 1; idx < NUM_OF_PARTICLES; idx++)
       {
         particles[idx] = Particle(START_RANGE_MIN, START_RANGE_MAX);
       }
+
+      Particle gBest;
 
       clock_t cpu_begin = clock();
       pso(particles, gBest, MAX_EPOCHS, MAX_STALL);

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -436,7 +436,7 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       }
 
       clock_t cpu_begin = clock();
-      pso(&particles, &gBest, MAX_EPOCHS, MAX_STALL);
+      pso(particles, gBest, MAX_EPOCHS, MAX_STALL);
       clock_t cpu_end = clock();
 
       printf("Time elapsed:%10.3lf s\n", (double)(cpu_end - cpu_begin) / CLOCKS_PER_SEC);


### PR DESCRIPTION
* For any given particle p, this update removes any recomputation of the NCC fitness value.
* Replaces arrays with vectors
* This drops the per frame opt time from ~9 to ~18 seconds to around ~3 to ~ 6 seconds
* Based off of #221 
    * It would appear that most of the time gained was from these API changes, however, there still is ~.5 sec per frame left on the table from adding the multithreading. 