### PR TITLE
PERF: Introduce particle data structure for PSO (#223)

### DIFF
--- a/libautoscoper/src/PSO.hpp
+++ b/libautoscoper/src/PSO.hpp
@@ -12,6 +12,8 @@
 #include <stdlib.h>
 #include <time.h>
 #include <math.h>
+#include <ostream>
+#include <vector>
 const int NUM_OF_PARTICLES = 100;
 const int NUM_OF_DIMENSIONS = 6;
 const float c1 = 1.5f;
@@ -24,6 +26,28 @@ void intializeRandom();
 
 float getRandom(float low, float high);
 float getRandomClamped();
-float host_fitness_function(float x[]);
+float host_fitness_function(const std::vector<float>& x);
 
-void pso(float *positions, float *velocities, float *pBests, float *gBest, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);
+struct Particle {
+  float NCC;
+  std::vector<float> Position;
+  std::vector<float> Velocity;
+
+  // Copy constructor
+  Particle(const Particle& p);
+  // Default constructor
+  Particle();
+  Particle(const std::vector<float>& pos);
+  Particle(float start_range_min, float start_range_max);
+  // Assignment operator
+  Particle& operator=(const Particle& p);
+
+  void updateVelocityAndPosition(const Particle& pBest, const Particle& gBest, float omega);
+  void initializePosition(float start_range_min, float start_range_max);
+};
+
+// Stream operator
+extern std::ostream& operator<<(std::ostream& os, const std::vector<float>& values);
+extern std::ostream& operator<<(std::ostream& os, const Particle& p);
+
+Particle pso(float start_range_min, float start_range_max, unsigned int MAX_EPOCHS, unsigned int MAX_STALL);

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -409,7 +409,7 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
     if (optimization_method == 0) // 0: PSO + Downhill Simplex, 1: Downhill Simplex
     {
       // PSO Algorithm
-      double xyzypr_manip[6] = { 0 };
+
       //int gBest = 0;
       //int gBestTest = 1000;
       int stall_iter = 0;
@@ -419,61 +419,19 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       unsigned int MAX_EPOCHS = max_iter;
       unsigned int MAX_STALL = max_stall_iter;
 
-      float positions[NUM_OF_PARTICLES*NUM_OF_DIMENSIONS];
-      float velocities[NUM_OF_PARTICLES*NUM_OF_DIMENSIONS];
-      float pBests[NUM_OF_PARTICLES*NUM_OF_DIMENSIONS];
-      float gBest[NUM_OF_DIMENSIONS];
-
-      srand((unsigned)time(NULL));
-
-      for (int i = 0; i < NUM_OF_PARTICLES*NUM_OF_DIMENSIONS; i++)
-      {
-        if (i >= NUM_OF_DIMENSIONS) {
-          positions[i] = getRandom(START_RANGE_MIN, START_RANGE_MAX);
-        }
-        // First point will be the initial position
-        else {
-          //if (j > 1)
-          //{
-            positions[i] = (float)0.0;
-          //}
-          //else
-          //{
-          //  positions[i] = (float)0.2; // Noise for refinements
-          //}
-        }
-        pBests[i] = positions[i];
-        velocities[i] = 0;
-      }
-
-      for (int i = 0; i < NUM_OF_DIMENSIONS; i++)
-      {
-        gBest[i] = pBests[i];
-      }
-
       clock_t cpu_begin = clock();
-
-      pso(positions, velocities, pBests, gBest, MAX_EPOCHS, MAX_STALL);
-      //cuda_pso(positions, velocities, pBests, gBest, MAX_EPOCHS);
-
+      Particle gBest = pso(START_RANGE_MIN, START_RANGE_MAX, MAX_EPOCHS, MAX_STALL);
       clock_t cpu_end = clock();
 
       printf("Time elapsed:%10.3lf s\n", (double)(cpu_end - cpu_begin) / CLOCKS_PER_SEC);
 
-      std::cout << "Pose change from initial position: ";
-      for (int i = 0; i < NUM_OF_DIMENSIONS; i++)
-      {
-        if (i == NUM_OF_DIMENSIONS - 1)
-        {
-          std::cout << gBest[i] << std::endl;
-        }
-        else {
-          std::cout << gBest[i] << ",";
-        }
-        xyzypr_manip[i] = gBest[i];
-      }
+      using ::operator<<; // Access the stream operator from the global namespace
+      std::cout << "Pose change from initial position: " << gBest.Position << std::endl;
 
-      printf("Minimum NCC from PSO = %f\n", host_fitness_function(gBest));
+      printf("Minimum NCC from PSO = %f\n", gBest.NCC);
+
+      double xyzypr_manip[NUM_OF_DIMENSIONS] = { 0 };
+      std::copy(gBest.Position.begin(), gBest.Position.begin() + NUM_OF_DIMENSIONS, xyzypr_manip);
 
       manip = CoordFrame::from_xyzAxis_angle(xyzypr_manip);
       // PSO End
@@ -494,15 +452,6 @@ void Tracker::optimize(int frame, int dFrame, int repeats, int opt_method, unsig
       trial_.getYawCurve(-1)->insert(trial_.frame, xyzypr[3]);
       trial_.getPitchCurve(-1)->insert(trial_.frame, xyzypr[4]);
       trial_.getRollCurve(-1)->insert(trial_.frame, xyzypr[5]);
-
-
-      // Get Current Pose
-      double xyzypr[6] = { (*trial_.getXCurve(-1))(trial_.frame),
-        (*trial_.getYCurve(-1))(trial_.frame),
-        (*trial_.getZCurve(-1))(trial_.frame),
-        (*trial_.getYawCurve(-1))(trial_.frame),
-        (*trial_.getPitchCurve(-1))(trial_.frame),
-        (*trial_.getRollCurve(-1))(trial_.frame) };
 
       // DOWNHILL SIMPLEX
       // Generate the 7 vertices that form the initial simplex. Because


### PR DESCRIPTION
:warning: This pull request was created to include the changes originally included through this pull-request https://github.com/BrownBiomechanics/Autoscoper/pull/223

For the sake of having a clean history and considering the updated `main` branch has not been referenced externally, `main` was forced push to https://github.com/BrownBiomechanics/Autoscoper/commit/73eb359dcd70878c4b4c28471fd2684c08bd3014

----------

Refactor the Particle Swarm Optimization (PSO) implementation by introducing a specialized Particle data structure alongside a particle collection. This structure allows us to efficiently manage and track computed Normalized Cross-Correlation (NCC) values for each particle. As a result, we now evaluate each particle only once per iteration, as opposed to between 2 and 5 times in the worst-case scenario.

This optimization has led to a remarkable reduction in per-frame execution time on a typical workstation using the OpenCL back-end, dropping it from the range of 9 to 18 seconds to a much-improved 3 to 6 seconds.

In the previous implementation, a for loop iterated over all particles, involving multiple calls to the `host_fitness_function`:

* The first two calls determined if the current particle's NCC value was better than the "best" within the current iteration.
* The subsequent two calls were used to assess whether the current particle was better than the "global best".
* The final call was responsible for updating the global best value.

By introducing the Particle data structure and revising the workflow, we have streamlined the computation process, resulting in a substantial performance boost.