### PR TITLE
PERF: Union viewport for drr and rad clipping

### DIFF
--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -1211,7 +1211,7 @@ bool AutoscoperMainWindow::openTrial(QString filename){
       load_tracking_results(tracking_path, 1, default_saving_format, 1, 0, 0, 0, iVol);
     }
 
-    on_actionInsert_Key_triggered(true);
+    //on_actionInsert_Key_triggered(true);
     // on_actionDelete_triggered(true);
     //
     return true;


### PR DESCRIPTION
Using both drr projection and radiograph, the union of the images in normalized coordinates is retained for ncc calc.

In response to #203 and #225 , 
still needs checks for if drr isn't overlapping rad, calculation of union_viewport should probably go into a subfunction

![unionVp](https://github.com/BrownBiomechanics/Autoscoper/assets/65619862/b9aabafc-2ac0-4662-939f-a95db5f4776f)


Working from the shoulder data in #225  This is the updated frame 12: (which does not chash on key frame)
![pair_mutualClipped_rad_drr](https://github.com/BrownBiomechanics/Autoscoper/assets/65619862/fa6ccc1b-41fb-4b5c-acac-0498b91d3bd6)

