### PR TITLE
BUG: Clip bounds of DRR projection to the bounds of the radiograph

### DIFF
--- a/libautoscoper/src/Camera.cpp
+++ b/libautoscoper/src/Camera.cpp
@@ -442,8 +442,10 @@ namespace xromm
     if (fx == 0 || fy == 0) {
       throw std::runtime_error("Invalid camera parameters (fx or fy is zero)");
     }
+    // viewport_[0] and viewport[1] approximately describe the x and y viewport coordinates of the (0,0) pixel
     viewport_[0] = -(2.0f*cx - size_[0]) / fx;
     viewport_[1] = -(2.0f*cy - size_[1]) / fy;
+    // viewport_[2] and viewport[3] approximately describe the width and height of the viewport
     viewport_[2] = 2.0f* size_[0] / fx;
     viewport_[3] = 2.0f* size_[1] / fy;
   }
@@ -462,7 +464,7 @@ namespace xromm
 
     // Calculate the vertices at the corner of the image plane.
     double image_plane_center[3];
-    coord_frame_.point_to_world_space(image_plane_trans, image_plane_center);
+    coord_frame_.point_to_world_space(image_plane_trans, image_plane_center); // Convert from camera space to world space
 
     double half_width = scale * size_[0] / 2.0;
     double half_height = scale * size_[1] / 2.0;

--- a/libautoscoper/src/Tracker.hpp
+++ b/libautoscoper/src/Tracker.hpp
@@ -104,7 +104,7 @@ namespace xromm
 
 
   private:
-    void calculate_viewport(const CoordFrame& modelview, double* viewport) const;
+    bool calculate_viewport(const CoordFrame& modelview, const Camera& camera, double* viewport) const;
 
     int optimization_method = (int)0;
     int cf_model_select = (int)0;


### PR DESCRIPTION
After meeting with @amymmorton this approach may be the way to move forward. However, a deeper dive into the geometry and the projections will likely need to be done later on.

This PR introduces the following:
*  Computation of the bounds of the radiograph image on the film plane (located at z = -2 or 2 units in front of the camera)
* Checking that the 2D DRR image falls within the bounds of the radiograph
* Clipping the bounds of the 2D DRR image to be at most the bounds of the radiograph

Successfully merging this PR should close the following PRs and issues:
* Closes #203
* Closes #229
* Closes #211

### Images and Diagrams

![PXL_20231108_195705752](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/16ab840a-8042-41b8-af04-42927465e83a)

 
| Position in Autoscoper | Left Cam | Right Cam | 
| --- | ---- | --- |
| ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/970be6fa-d46c-49dd-a94b-1e0ca3550e6e) | ![image_cam04](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/aab27121-5c57-4e77-b8f9-8f533745324e) ![image_cam05](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/937a7f7b-c823-4c71-8793-acb958debf16) | ![image_cam06](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/153baf7e-20b9-43b0-a128-62e9e2251680) ![image_cam07](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/47be91e2-4c8d-4839-8c1e-86901eeaec50) |

For the left and right cam columns, the top image is DRR bottom image is the radiograph. 

| Position in Autoscoper | Terminal |
| --- | --- |
| ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/f753f4ca-ac33-4116-8889-8bfb30962e5f) | ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/354e1b2c-f12b-48d6-934a-285b7206b88b) |




