### PR TITLE
BUG: Fix PSO Particle struct position initialization

### DIFF
--- a/libautoscoper/src/PSO.cpp
+++ b/libautoscoper/src/PSO.cpp
@@ -71,7 +71,7 @@ void Particle::updateVelocityAndPosition(const Particle& pBest, const Particle& 
 
 void Particle::initializePosition(float start_range_min, float start_range_max) {
   for (int dim = 0; dim < NUM_OF_DIMENSIONS; dim++) {
-    this->Position.push_back(getRandom(start_range_min, start_range_max));
+    this->Position[dim] = getRandom(start_range_min, start_range_max);
   }
 }
 


### PR DESCRIPTION
Since we started initializing the position to be `{0., 0., 0., 0., 0., 0.}` the call to `push_back` is not needed. 