### PR TITLE
EOS Projection Support

### DIFF
--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -1214,6 +1214,7 @@ bool AutoscoperMainWindow::openTrial(QString filename){
     on_actionInsert_Key_triggered(true);
     // on_actionDelete_triggered(true);
     //
+    this->tracker->projectEOS(0);
     return true;
   }
   catch (std::exception& e) {

--- a/libautoscoper/src/Tracker.hpp
+++ b/libautoscoper/src/Tracker.hpp
@@ -102,6 +102,8 @@ namespace xromm
 
     void getFullDRR(unsigned int volumeID) const;
 
+    void projectEOS(unsigned int volumeID) const;
+
 
   private:
     bool calculate_viewport(const CoordFrame& modelview, const Camera& camera, double* viewport) const;

--- a/libautoscoper/src/gpu/opencl/CMakeLists.txt
+++ b/libautoscoper/src/gpu/opencl/CMakeLists.txt
@@ -14,6 +14,7 @@ set(opencl_HEADERS
   src/gpu/opencl/BackgroundRenderer.hpp
   src/gpu/opencl/DRRBackground.hpp
   src/gpu/opencl/Mult.hpp
+  src/gpu/opencl/EOSRayCaster.hpp
 )
 
 set(opencl_SOURCES
@@ -30,6 +31,7 @@ set(opencl_SOURCES
   src/gpu/opencl/BackgroundRenderer.cpp
   src/gpu/opencl/DRRBackground.cpp
   src/gpu/opencl/Mult.cpp
+  src/gpu/opencl/EOSRayCaster.cpp
 )
 
 

--- a/libautoscoper/src/gpu/opencl/EOSRayCaster.cpp
+++ b/libautoscoper/src/gpu/opencl/EOSRayCaster.cpp
@@ -1,0 +1,172 @@
+#include "EOSRayCaster.hpp"
+#include <sstream>
+
+namespace xromm {
+  namespace gpu {
+#include "gpu/opencl/kernel/EosRayCaster.cl.h"
+
+#define BX 16
+#define BY 16
+
+    static Program eos_ray_caster_program_;
+    static int num_casters = 0;
+
+    EOSRayCaster::EOSRayCaster() : volumeDescription_(0),
+                                   name_(""),
+                                   sid_(0.f),
+                                   sdd_(0.f),
+                                   lambda_(0.f),
+                                   lambdaZ_(0.f),
+                                   cutoff_(0.f),
+                                   intensity_(0.f),
+                                   isLateral_(0),
+                                   z0_(0),
+                                   R_(0),
+                                   C_(0) {
+      std::stringstream name_stream;
+      name_stream << "EOS DRR Renderer" << (++num_casters);
+      name_ = name_stream.str();
+      visible_ = true;
+      worldToModelArray_[0] = 1.f;
+      worldToModelArray_[5] = 1.f;
+      worldToModelArray_[10] = 1.f;
+      worldToModelArray_[15] = 1.f;
+      worldToModelBuffer_ = new Buffer(16 * sizeof(float), CL_MEM_READ_ONLY);
+      worldToModelBuffer_->read(worldToModelArray_);
+      worldToModelMatrix_ = new CoordFrame();
+      worldToModelMatrix_->from_matrix(&(worldToModelArray_[0]));
+
+      viewportBuffer_ = new Buffer(4 * sizeof(float), CL_MEM_READ_ONLY);
+    }
+
+    EOSRayCaster::~EOSRayCaster() {
+      if (worldToModelBuffer_) delete worldToModelBuffer_;
+      if (viewportBuffer_) delete viewportBuffer_;
+    }
+
+    void EOSRayCaster::setVolume(VolumeDescription& volume) {
+      volumeDescription_ = &volume;
+    }
+
+    void EOSRayCaster::setWorldToModelMatrix(CoordFrame& worldToModelMatrix) {
+      worldToModelMatrix_ = &worldToModelMatrix;
+      worldToModelMatrix_->to_matrix(&(worldToModelArray_[0])); // Column-major
+      worldToModelBuffer_->read(worldToModelArray_);
+    }
+
+    void EOSRayCaster::setGeometry(const float& sid, const float& sdd, const float& lambda, const float& lambdaZ, const float& cutoff, const float& intensity, bool isLateral, const unsigned int& R, const unsigned int& C) {
+      sid_ = sid;
+      sdd_ = sdd;
+      lambda_ = lambda;
+      lambdaZ_ = lambdaZ;
+      cutoff_ = cutoff;
+      intensity_ = intensity;
+      isLateral_ = (unsigned int)isLateral;
+      R_ = R;
+      C_ = C;
+    }
+
+    void EOSRayCaster::render(const Buffer* buffer, unsigned int width, unsigned int height) {
+      if (!volumeDescription_) {
+        std::cerr << "EOSRayCaster: WARNING: No volume loaded." << std::endl;
+        return;
+      }
+
+      if (!visible_) {
+        buffer->fill((char)0x00);
+        return;
+      }
+
+      if (!viewportBuffer_) {
+        std::cerr << "EOSRayCaster: WARNING: No viewport loaded." << std::endl;
+        return;
+      }
+
+      Kernel* kernel = eos_ray_caster_program_.compile(EosRayCaster_cl, "eos_project_drr");
+
+      kernel->block2d(BX, BY);
+      kernel->grid2d((height + BX - 1) / BX, (width + BY - 1) / BY);
+
+      // add offset width,height
+
+      kernel->addBufferArg(buffer);
+      kernel->addImageArg(volumeDescription_->image());
+      kernel->addBufferArg(worldToModelBuffer_);
+      kernel->addBufferArg(viewportBuffer_);
+      kernel->addArg(z0_);
+      kernel->addArg(lambda_);
+      kernel->addArg(lambdaZ_);
+      kernel->addArg(sid_);
+      kernel->addArg(sdd_);
+      kernel->addArg(C_);
+      kernel->addArg(R_);
+      kernel->addArg(isLateral_);
+      kernel->addArg(cutoff_);
+      kernel->addArg(intensity_);
+      kernel->addArg(width);
+      kernel->addArg(height);
+
+      kernel->launch();
+
+      delete kernel;
+    }
+
+    void EOSRayCaster::calculateViewport() {
+      if (!volumeDescription_) {
+        std::cerr << "EOSRayCaster: WARNING: No volume loaded." << std::endl;
+        return;
+      }
+      if (!worldToModelMatrix_) {
+        std::cerr << "EOSRayCaster: WARNING: No world to model matrix." << std::endl;
+        return;
+      }
+
+      double corners[24] = { 0,0,-1,0,0,0, 0,1,-1,0,1,0, 1,0,-1,1,0,0,1,1,-1,1,1,0 };
+      double min_max[4] = { C_, R_, 0, 0 }; // min_x, min_y, max_x, max_y
+
+      for (int j = 0; j < 8; j++) {
+        // Calculate the location of each corner in object space
+        corners[3 * j + 0] = (corners[3 * j + 0] - volumeDescription_->invTrans()[0]) / volumeDescription_->invScale()[0];
+        corners[3 * j + 1] = (corners[3 * j + 1] - volumeDescription_->invTrans()[1]) / volumeDescription_->invScale()[1];
+        corners[3 * j + 2] = (corners[3 * j + 2] - volumeDescription_->invTrans()[2]) / volumeDescription_->invScale()[2];
+
+        // Move the corner into world space
+        double corner_world[3];
+        worldToModelMatrix_->inverse().point_to_world_space(&corners[3*j], corner_world);
+
+        // Project the corner onto the radiograph plane
+        double corner_image[2];
+        if (!isLateral_)
+          corner_image[0] = (C_ / 2) - (sid_ * corner_world[0]) / (lambda_ * (sid_ + corner_world[1]));
+        else
+          corner_image[0] = (C_ / 2) - (sid_ * corner_world[1]) / (lambda_ * (sid_ + corner_world[2]));
+        corner_image[1] = (z0_ - corner_world[2]) / lambdaZ_;
+
+        // Make sure the corner is within the radiograph
+        if (corner_image[0] < 0) corner_image[0] = 0;
+        if (corner_image[0] > C_) corner_image[0] = C_;
+        if (corner_image[1] < 0) corner_image[1] = 0;
+        if (corner_image[1] > R_) corner_image[1] = R_;
+
+        // Update the bounding box
+        if (corner_image[0] < min_max[0]) min_max[0] = corner_image[0];
+        if (corner_image[0] > min_max[2]) min_max[2] = corner_image[0];
+        if (corner_image[1] < min_max[1]) min_max[1] = corner_image[1];
+        if (corner_image[1] > min_max[3]) min_max[3] = corner_image[1];
+      }
+
+      // Calculate the viewport
+      //viewport_[0] = (int)floor(min_max[0]); // x
+      //viewport_[1] = (int)floor(min_max[1]); // y
+      //viewport_[2] = (int)ceil(min_max[2]) - viewport_[0]; // width
+      //viewport_[3] = (int)ceil(min_max[3]) - viewport_[1]; // height
+
+      viewport_[0] = 0;
+      viewport_[1] = 0;
+      viewport_[2] = C_;
+      viewport_[3] = R_;
+
+      viewportBuffer_->read(viewport_);
+
+    }
+} } // namespace xromm::gpu

--- a/libautoscoper/src/gpu/opencl/EOSRayCaster.hpp
+++ b/libautoscoper/src/gpu/opencl/EOSRayCaster.hpp
@@ -1,0 +1,97 @@
+#ifndef XROMM_EOS_RAY_CASTER_HPP
+#define XROMM_EOS_RAY_CASTER_HPP
+
+#include <string>
+
+#include "OpenCL.hpp"
+#include "VolumeDescription.hpp"
+#include "CoordFrame.hpp"
+
+namespace xromm {
+  namespace gpu {
+    class EOSRayCaster {
+    public:
+      EOSRayCaster();
+      ~EOSRayCaster();
+
+      void setVolume(VolumeDescription& volume);
+      void setWorldToModelMatrix(CoordFrame& worldToModelMatrix);
+      void setGeometry(const float& sid, const float& sdd, const float& lambda, const float& lambdaZ, const float& cutoff, const float& intensity, bool isLateral, const unsigned int& R, const unsigned int& C);
+      void render(const Buffer* buffer, unsigned int width, unsigned int height);
+
+      void calculateViewport();
+
+      double* viewport() {
+        return viewport_;
+      }
+
+      float getSourceToIsocenterDistance() const {
+        return sid_;
+      }
+      void setSourceToIsocenterDistance(const float& sid) {
+        sid_ = sid;
+      }
+      float getSourceToDetectorDistance() const {
+        return sdd_;
+      }
+      void setSourceToDetectorDistance(const float& sdd) {
+        sdd_ = sdd;
+      }
+      float getLambda() const {
+        return lambda_;
+      }
+      void setLambda(const float& lambda) {
+        lambda_ = lambda;
+      }
+      float getLambdaZ() const {
+        return lambdaZ_;
+      }
+      void setLambdaZ(const float& lambdaZ) {
+        lambdaZ_ = lambdaZ;
+      }
+      float getCutoff() const {
+        return cutoff_;
+      }
+      float getMinCutoff() const {
+        return volumeDescription_->minValue();
+      }
+      float getMaxCutoff() const {
+        return volumeDescription_->maxValue();
+      }
+      void setCutoff(const float& cutoff) {
+        cutoff_ = cutoff;
+      }
+      const std::string& getName() const {
+        return name_;
+      }
+      void setName(const std::string& name) {
+        name_ = name;
+      }
+      void setVisible(const bool& visible) {
+        visible_ = visible;
+      }
+
+
+    private:
+      CoordFrame* worldToModelMatrix_;
+      double worldToModelArray_[16] = { 0.0 };
+      Buffer* worldToModelBuffer_;
+      Buffer* viewportBuffer_;
+      std::string name_;
+      VolumeDescription* volumeDescription_;
+      float sid_;
+      float sdd_;
+      float lambda_;
+      float lambdaZ_;
+      float cutoff_;
+      float intensity_;
+      unsigned int isLateral_;
+      bool visible_;
+      unsigned int z0_;
+      unsigned int R_;
+      unsigned int C_;
+      double viewport_[4] = {0.0};
+    };
+
+} } // namespace xromm::gpu
+#endif // XROMM_EOS_RAY_CASTER_HPP

--- a/libautoscoper/src/gpu/opencl/kernel/CMakeLists.txt
+++ b/libautoscoper/src/gpu/opencl/kernel/CMakeLists.txt
@@ -14,6 +14,7 @@ set(opencl_shaders
   gpu/opencl/kernel/BackgroundRenderer.cl
   gpu/opencl/kernel/DRRBackground.cl
   gpu/opencl/kernel/Mult.cl
+  gpu/opencl/kernel/EosRayCaster.cl
 )
 
 foreach(SHADER_FILENAME ${opencl_shaders})

--- a/libautoscoper/src/gpu/opencl/kernel/EosRayCaster.cl
+++ b/libautoscoper/src/gpu/opencl/kernel/EosRayCaster.cl
@@ -1,0 +1,81 @@
+__kernel void eos_project_drr(
+  __global float* img,
+  __read_only image3d_t image,
+  __constant float* world_to_model_mat,
+  __constant float* viewport,
+  const unsigned int z0,
+  const float lambda,
+  const float lambda_z,
+  const float sid,
+  const float sdd,
+  const unsigned int C,
+  const unsigned int R,
+  const unsigned int is_lateral,
+  const float cutoff,
+  const float intensity,
+  const unsigned int width,
+  const unsigned int height
+) {
+  // img is of size width x height
+  const int i = get_global_id(1); // Column index in final image
+  const int j = get_global_id(0); // Row index in final image
+
+  // Entire image is of size C x R so we need to offset the viewport
+  const unsigned int v = (unsigned int)(viewport[1] + j);
+  const unsigned int u = (unsigned int)(viewport[0] + i);
+
+
+  if (i >= width || j >= height) {
+    return;
+  }
+
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | // Natural coordinates
+    CLK_ADDRESS_CLAMP | // Clamp to zeros at borders
+    CLK_FILTER_NEAREST; // No interpolation
+
+  float z = z0 - lambda_z * u; // height index in volume (world coordinates)
+
+
+  // Emiter position (world coordinates) Ray origin
+  float3 e = (float3)(-sid, 0.f, z);
+  if (is_lateral) {
+    e = (float3)(0.f, -sid, z);
+  }
+
+  // Detector position (world coordinates)
+  float3 d = (float3)(sdd - sid, ((v - (C / 2.f)) * lambda * sdd) / sid, z);
+  if (is_lateral) {
+    d = (float3)(((C / 2.f - v) * lambda * sdd) / sid, sdd - sid, z);
+  }
+
+  // Ray direction
+  float3 r = normalize(d - e);
+
+  // Ray marching back to front
+  float density = 0.f;
+  float t = sdd; // far plane is the detector
+  float near = 0.f; // near plane is the emitter
+  float step = .1f;
+  while (t > near) {
+    float3 p = e + t * r; // Point on ray
+    // Transform to model coordinates
+    p = (float3)(dot((float3)(world_to_model_mat[0], world_to_model_mat[4], world_to_model_mat[8]), p),
+      dot((float3)(world_to_model_mat[1], world_to_model_mat[5], world_to_model_mat[9]), p),
+      dot((float3)(world_to_model_mat[2], world_to_model_mat[6], world_to_model_mat[10]), p));
+    p = p + (float3)(world_to_model_mat[12], world_to_model_mat[13], world_to_model_mat[14]); // Translate
+    float value = read_imagef(image, sampler, (float4)(p.x, (1-p.y), -p.z, 0.f)).x; // Sample volume
+    if (value > 0.f)
+      printf("%f\n",value);
+    if (value > cutoff) {
+      density += value * step;
+    }
+    t -= step;
+  }
+
+
+  // Write to image
+  if (density > 0) {
+    img[j * width + i] = density / intensity;
+  }
+
+}


### PR DESCRIPTION
# EOS Project Support

This PR adds support for the EOS full-body scanner. A few things need to be addressed before this is integrated.

- [ ] Sampling the Volume within Autoscoper. I suspect this has something to do with the normalized volume coordinates that Autoscoper uses.
    - I was able to generate some projects using the kernel in a stand-alone application. 
    - The kernel and some instructions can be found in [this repo](https://github.com/NicerNewerCar/EOS-Test-Bed)
- [ ] Viewport cropping is not working, so as of right now we have to generate an entire CxR DRR to project a volume
- [ ] Fuzziness in projections
   -  This may be due to pixel/sensor pitch/scaling
- [ ] We need to come to a consensus on how we are going to be loading the EOS parameters (We can easily create a camera object from these parameters for the Rad renderer)
    - Most likely we will need to add a fourth camera file type to handle this.
- [ ] CUDA support
    - This is OpenCL only as of now


### EOS Geometry Representation
![EOS-geo](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/e3e87d92-896a-4ee6-9830-715c3650b41c)

![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/2ea83e23-c654-4d32-98f7-66c12f87261c)


### Some example DRRs 

| Frontal | Lateral |
| --- | --- |
| ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/0645d9ee-4a24-4806-96d9-49aa499bf449) | ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/b7c98851-afe1-4625-b4f1-66f68b896569) |

| Frontal | Lateral |
| --- | --- |
| ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/b4a8e9b4-8f65-45c6-81e1-e6f5a3c40b71) | ![image](https://github.com/BrownBiomechanics/Autoscoper/assets/30351234/73262030-16e1-479e-86ef-87bc00687d34) |



 