### PR TITLE
COMP: Add support for appending a suffix to Autoscoper artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,11 @@ if(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   message(STATUS "Setting Autoscoper_OPENCL_USE_ICD_LOADER to ${Autoscoper_OPENCL_USE_ICD_LOADER}")
 endif()
 
+set(Autoscoper_ARTIFACT_SUFFIX "" CACHE STRING "Suffix for Autoscoper artifact names")
+mark_as_advanced(Autoscoper_ARTIFACT_SUFFIX)
+mark_as_superbuild(Autoscoper_ARTIFACT_SUFFIX)
+message(STATUS "Setting Autoscoper_ARTIFACT_SUFFIX to '${Autoscoper_ARTIFACT_SUFFIX}'")
+
 #-----------------------------------------------------------------------------
 # Set a default build type if none was specified
 #-----------------------------------------------------------------------------

--- a/autoscoper/CMakeLists.txt
+++ b/autoscoper/CMakeLists.txt
@@ -115,6 +115,10 @@ if(Autoscoper_CONFIGURE_LAUCHER_SCRIPT AND CMAKE_VERSION VERSION_LESS "3.20" AND
 endif()
 
 set_target_properties(autoscoper PROPERTIES
+  OUTPUT_NAME "autoscoper${Autoscoper_ARTIFACT_SUFFIX}"
+)
+
+set_target_properties(autoscoper PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_BIN_DIR}"
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_BIN_DIR}"
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_LIB_DIR}"

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -94,6 +94,12 @@ target_compile_definitions(libautoscoper PUBLIC
 )
 
 set_target_properties(libautoscoper PROPERTIES
+  RUNTIME_OUTPUT_NAME "libautoscoper${Autoscoper_ARTIFACT_SUFFIX}"
+  LIBRARY_OUTPUT_NAME "libautoscoper${Autoscoper_ARTIFACT_SUFFIX}"
+  ARCHIVE_OUTPUT_NAME "libautoscoper${Autoscoper_ARTIFACT_SUFFIX}"
+)
+
+set_target_properties(libautoscoper PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_BIN_DIR}"
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_BIN_DIR}"
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Autoscoper_LIB_DIR}"


### PR DESCRIPTION
The option `Autoscoper_ARTIFACT_SUFFIX` allows users to specify a custom suffix to be appended to the names of Autoscoper artifacts, aiding in the unique identification of artifacts based on selected build options.

This is done anticipating the support for packaging multiple backend-specific versions of Autoscoper in `SlicerAutoscoperM`.