### PR TITLE
COMP: Add support for building against pre-built GLEW and TIFF projects

### DIFF
--- a/Superbuild/External_GLEW.cmake
+++ b/Superbuild/External_GLEW.cmake
@@ -61,6 +61,10 @@ if(NOT DEFINED GLEW_DIR AND NOT Autoscoper_USE_SYSTEM_${proj})
       ${${proj}_DEPENDENCIES}
     )
   set(GLEW_DIR ${EP_INSTALL_DIR}/${Autoscoper_LIB_DIR}/cmake/glew)
-  ExternalProject_Message(${proj} "GLEW_DIR:${GLEW_DIR}")
-  mark_as_superbuild(GLEW_DIR:PATH)
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
 endif()
+
+ExternalProject_Message(${proj} "GLEW_DIR:${GLEW_DIR}")
+mark_as_superbuild(GLEW_DIR:PATH)

--- a/Superbuild/External_TIFF.cmake
+++ b/Superbuild/External_TIFF.cmake
@@ -79,12 +79,15 @@ if((NOT DEFINED TIFF_INCLUDE_DIR
     set(TIFF_LIBRARY ${tiff_DIR}/${Autoscoper_LIB_DIR}/libtiff.so)
   endif()
 
-  mark_as_superbuild(
-    VARS
-      TIFF_INCLUDE_DIR:PATH
-      TIFF_LIBRARY:PATH
-    )
-
-  ExternalProject_Message(${proj} "TIFF_INCLUDE_DIR:${TIFF_INCLUDE_DIR}")
-  ExternalProject_Message(${proj} "TIFF_LIBRARY:${TIFF_LIBRARY}")
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
 endif()
+
+mark_as_superbuild(
+  VARS
+    TIFF_INCLUDE_DIR:PATH
+    TIFF_LIBRARY:PATH
+  )
+
+ExternalProject_Message(${proj} "TIFF_INCLUDE_DIR:${TIFF_INCLUDE_DIR}")
+ExternalProject_Message(${proj} "TIFF_LIBRARY:${TIFF_LIBRARY}")


### PR DESCRIPTION
This is done anticipating the support for packaging multiple backend-specific versions of Autoscoper in SlicerAutoscoperM.