### PR TITLE
ENH: Socket control drr visibility toggle

### DIFF
--- a/autoscoper/src/net/Socket.cpp
+++ b/autoscoper/src/net/Socket.cpp
@@ -418,6 +418,22 @@ void Socket::handleMessage(QTcpSocket * connection, char* data, qint64 length)
     }
     break;
 
+  case 17:
+    // Set the visablity of a volume
+    {
+      size_t offset = preamble_offset;
+
+      SocketReadValuePointerMacro(volumeID, qint32);
+      SocketReadValuePointerMacro(visible, qint32);
+
+      std::cerr << "Setting volume " << (int)*volumeID << " to have a visablity: " << (int)*visible << std::endl;
+
+      m_mainwindow->setVolumeVisibility(*volumeID, (bool)*visible);
+
+      connection->write(QByteArray(1, 17));
+    }
+    break;
+
   default:
     std::cerr << "Cannot handle message" << std::endl;
     connection->write(QByteArray(1,0));

--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -2503,3 +2503,7 @@ int AutoscoperMainWindow::getNumVolumes() {
 int AutoscoperMainWindow::getNumFrames() {
     return tracker->trial()->num_frames;
 }
+
+void AutoscoperMainWindow::setVolumeVisibility(int volume, bool visible) {
+  volumes_widget->setVolumeVisibility(volume, visible);
+}

--- a/autoscoper/src/ui/AutoscoperMainWindow.h
+++ b/autoscoper/src/ui/AutoscoperMainWindow.h
@@ -128,6 +128,7 @@ class AutoscoperMainWindow : public QMainWindow{
     void optimizeFrame(int volumeID, int frame, int dframe, int repeats, int opt_method, unsigned int max_iter, double min_limit, double max_limit, int cf_model, unsigned int stall_iter);
     int getNumVolumes();
     int getNumFrames();
+    void setVolumeVisibility(int volumeID, bool visible);
 
 
     // Backup Save

--- a/autoscoper/src/ui/VolumeDockWidget.cpp
+++ b/autoscoper/src/ui/VolumeDockWidget.cpp
@@ -61,6 +61,11 @@ void VolumeDockWidget::addVolume(const std::string& filename, int idx){
 
 }
 
+void VolumeDockWidget::setVolumeVisibility(unsigned int volume_index, bool visible) {
+  VolumeListWidgetItem* item = dynamic_cast<VolumeListWidgetItem*>(dock->listWidget->item(volume_index));
+  item->setVisibility(visible);
+}
+
 void VolumeDockWidget::on_listWidget_currentItemChanged (QListWidgetItem* current, QListWidgetItem* previous) {
   if (current != NULL)
   {

--- a/autoscoper/src/ui/VolumeDockWidget.h
+++ b/autoscoper/src/ui/VolumeDockWidget.h
@@ -23,6 +23,7 @@ class VolumeDockWidget : public QDockWidget{
 
     void clearVol();
     void addVolume(const std::string& filename, int idx);
+    void setVolumeVisibility(unsigned int volume_index, bool visible);
 
 
     QString getVolumeName(int volume_index);

--- a/autoscoper/src/ui/VolumeListWidgetItem.cpp
+++ b/autoscoper/src/ui/VolumeListWidgetItem.cpp
@@ -38,6 +38,10 @@ void VolumeListWidgetItem::setup(QListWidget* listWidget) {
   QObject::connect(visibilityCheckBox_, SIGNAL(toggled(bool)), this, SLOT(on_visiblilityCheckBox__toggled(bool)));
 }
 
+void VolumeListWidgetItem::setVisibility(bool visible) {
+  visibilityCheckBox_->setChecked(visible);
+}
+
 void VolumeListWidgetItem::on_visiblilityCheckBox__toggled(bool checked) {
   if (renderers_.size() > 0) {
     for (xromm::gpu::RayCaster* renderer : renderers_) {

--- a/autoscoper/src/ui/VolumeListWidgetItem.h
+++ b/autoscoper/src/ui/VolumeListWidgetItem.h
@@ -17,6 +17,7 @@ class VolumeListWidgetItem : public QObject, public QListWidgetItem {
   Q_OBJECT
 public:
   VolumeListWidgetItem(QListWidget* listWidget, const QString& name, AutoscoperMainWindow* main_window, std::vector< xromm::gpu::RayCaster*>* renderers);
+  void setVisibility(bool visible);
 private:
   std::vector< xromm::gpu::RayCaster*> renderers_;
   QCheckBox *visibilityCheckBox_;

--- a/scripts/matlab/AutoscoperConnection.m
+++ b/scripts/matlab/AutoscoperConnection.m
@@ -381,6 +381,17 @@ classdef AutoscoperConnection
             data = fread(obj.socket_descriptor, obj.socket_descriptor.BytesAvailable);
         end
 
+        function setVolumeVisibility(obj, volNum, visible)
+            if nargin < 3
+                error('Not enough input arguments');
+            end
+            fwrite(obj.socket_descriptor, [ ...
+                                           17 ...
+                                           typecast(int32(volNum), 'uint8') ...
+                                           typecast(int32(visible), 'uint8') ...
+                                          ]);
+        end
+
         function trackingDialog(obj, volNum, startframe, endframe, repeats, max_itr, min_lim, max_lim, max_stall_itr, dframe, opt_method, cf_model, opt_init_heuristic)
             % Performs optimization on a range of frames
             % Only obj, volNum, startframe, and endframe are required

--- a/scripts/python/PyAutoscoper/connect.py
+++ b/scripts/python/PyAutoscoper/connect.py
@@ -594,3 +594,15 @@ class AutoscoperConnection:
         response = self._send_command(0x0F)  # 15
         num_frames = struct.unpack("i", response[1:])[0]
         return num_frames
+
+    def setVolumeVisibility(self, volume: int, visible: bool) -> None:
+        """
+        Sets the visibility of the given volume
+
+        :param volume: The ID of the volume.
+        :param visible: If True makes the volume visible. If False make the volume invisible.
+
+        :raises AutoscoperServerError: If the server fails to get the number of frames
+        :raises AutoscoperConnectionError: If the connection to the server is lost
+        """
+        self._send_command(0x11, volume, int(visible))  # 17


### PR DESCRIPTION
- Closes #247 
- Adds Socket control for toggling the visibility of DRRs
- Defaults the visibility flag in the CUDA backend to `true`
- @amymmorton I don't have an active MATLAB license anymore, could you test the updated class?
   -  ~~**Note:** I haven't set the UI to update yet so the checkbox will still be checked~~

ToDo:
- [x] Get UI to update from the socket 
- [ ] Figure out if #246 is related to the checkbox