### PR TITLE
BUG: Ensure CUDA RayCaster is sets visible to true by default

### DIFF
--- a/libautoscoper/src/gpu/cuda/RayCaster.cpp
+++ b/libautoscoper/src/gpu/cuda/RayCaster.cpp
@@ -66,6 +66,7 @@ RayCaster::RayCaster() : volumeDescription_(0),
     std::stringstream name_stream;
     name_stream << "DrrRenderer" << (++num_ray_casters);
     name_ = name_stream.str();
+    visible_ = true;
 
     viewport_[0] = -1.0f;
     viewport_[1] = -1.0f;


### PR DESCRIPTION
Bug was introduced in commit 73eb359dcd70878c4b4c28471fd2684c08bd3014