### PR TITLE
ENH: Modernize CUDA integration using FindCUDAToolkit CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.17.5)
 
 project(Autoscoper)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17.5)
+cmake_minimum_required(VERSION 3.20.6)
 
 project(Autoscoper)
 

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -63,6 +63,28 @@ if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   # See https://docs.nvidia.com/cuda/archive/10.2/cuda-c-programming-guide/index.html#c-cplusplus-language-support
   set(CMAKE_CUDA_STANDARD 14)
   set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
+  if("$ENV{CUDAARCHS}" STREQUAL "" AND NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.23")
+      set(_cuda_achitectures "all")
+    else()
+      # Adapted from https://github.com/Kitware/CMake/blob/v3.29.0-rc1/Modules/Internal/CMakeCUDAArchitecturesAll.cmake
+      set(_cuda_achitectures
+        50 52 53
+        60 61 62 # >= 8.0
+        70 72 # >= 9.0
+        75 # >= 10.0
+        80 # >= 11.0
+        # 86 # >= 11.1
+        # 87 # >= 11.4
+        # 88 89 # >= 11.8
+        )
+      # only generate jit code for the newest arch
+      list(POP_BACK _cuda_achitectures _latest_arch)
+      list(TRANSFORM _cuda_achitectures APPEND "-real")
+      list(APPEND _cuda_achitectures ${_latest_arch})
+    endif()
+    set(ENV{CUDAARCHS} "${_cuda_achitectures}")
+  endif()
   enable_language(CUDA)
   find_package(CUDAToolkit REQUIRED)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/CMakeLists.txt)

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -59,14 +59,22 @@ list(APPEND libautoscoper_SOURCES
   )
 
 if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
-  find_package(CUDA REQUIRED)
+  # CUDA 10.2 supports C++ up to version 14
+  # See https://docs.nvidia.com/cuda/archive/10.2/cuda-c-programming-guide/index.html#c-cplusplus-language-support
+  set(CMAKE_CUDA_STANDARD 14)
+  set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
+  enable_language(CUDA)
+  find_package(CUDAToolkit REQUIRED)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/CMakeLists.txt)
-  # Ensure calls to "target_link_libraries()" used in "CUDA_ADD_LIBRARY()" also
-  # specify a scope keyword.
-  set(CUDA_LINK_LIBRARIES_KEYWORD "PUBLIC")
-  CUDA_ADD_LIBRARY(libautoscoper STATIC ${libautoscoper_SOURCES} ${libautoscoper_HEADERS} ${cuda_HEADERS} ${cuda_SOURCES} ${cuda_KERNEL_HEADERS} ${cuda_KERNEL})
+  add_library(libautoscoper STATIC ${libautoscoper_SOURCES} ${libautoscoper_HEADERS} ${cuda_HEADERS} ${cuda_SOURCES} ${cuda_KERNEL_HEADERS} ${cuda_KERNEL})
   target_include_directories(libautoscoper PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/cutil)
-  # Explicitly linking against CUDA_LIBRARIES is already done in "CUDA_ADD_LIBRARY()".
+  target_link_libraries(libautoscoper PUBLIC
+    CUDA::cudart_static
+  )
+  # The use of multiple .h and .cu files implies separate compilation units
+  set_target_properties(libautoscoper PROPERTIES
+    CMAKE_CUDA_SEPARABLE_COMPILATION ON
+  )
 elseif(Autoscoper_RENDERING_BACKEND STREQUAL "OpenCL")
   if(Autoscoper_OPENCL_USE_ICD_LOADER)
     find_package(OpenCLHeaders REQUIRED)


### PR DESCRIPTION
_:warning: This pull request was created to integrate changes originally included through pull-request https://github.com/BrownBiomechanics/Autoscoper/pull/238. Since the changes were integrated in hast without having the corresponding `SlicerAutoscoperM` changes ready, the `main` branch was forced push to https://github.com/BrownBiomechanics/Autoscoper/commit/7df4365ecb1919fa10cb3e67a836467db0686f2e_

----------

See https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html

> The [FindCUDA](https://cmake.org/cmake/help/latest/module/FindCUDA.html#module:FindCUDA) module has been deprecated since CMake 3.10. CMake 3.27 and above prefer to not provide the module. This policy provides compatibility for projects that have not been ported away from it.

Source: https://cmake.org/cmake/help/latest/policy/CMP0146.html