### PR TITLE
BUG: Ensure consistent handling of line endings when reading trial/filters/camera files

### DIFF
--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -60,6 +60,7 @@
 #include "ui/NewTrialDialog.h"
 #include "ui_NewTrialDialog.h"
 
+#include "asys/SystemTools.hxx"
 #include "Trial.hpp"
 #include "View.hpp"
 #include "Tracker.hpp"
@@ -1010,7 +1011,7 @@ bool AutoscoperMainWindow::load_tracking_results(QString filename,
 
   double m[16];
   std::string line, value;
-  for (int i = 0; i < tracker->trial()->num_frames && std::getline(file, line); ++i) {
+  for (int i = 0; i < tracker->trial()->num_frames && asys::SystemTools::GetLineFromStream(file, line); ++i) {
     std::istringstream lineStream(line);
     for (int k = start; k < stop; k++) {
       for (int j = 0; j < (save_as_matrix ? 16 : 6) && std::getline(lineStream, value, s); ++j) {

--- a/autoscoper/src/ui/FilterTreeWidget.cpp
+++ b/autoscoper/src/ui/FilterTreeWidget.cpp
@@ -52,6 +52,7 @@
 #include "ui/FilterDockWidget.h"
 #include "ui/AutoscoperMainWindow.h"
 
+#include "asys/SystemTools.hxx"
 #include "View.hpp"
 #include <math.h>
 
@@ -160,7 +161,7 @@ void FilterTreeWidget::action_LoadSettings_triggered()
     }
 
     std::string line, key;
-    while (std::getline(file, line)) {
+    while (asys::SystemTools::GetLineFromStream(file, line)) {
       if (line.compare("DrrRenderer_begin") == 0) {
         for (int i = 0; i < cameraTreeItem->childCount(); i++) {
           ModelViewTreeWidgetItem* modelviewItem = dynamic_cast<ModelViewTreeWidgetItem*>(cameraTreeItem->child(i));
@@ -257,7 +258,7 @@ void FilterTreeWidget::loadAllSettings(QString directory)
       QString filename = directory + camera->getName() + ".vie";
       std::ifstream file(filename.toStdString().c_str(), std::ios::in);
       std::string line, key;
-      while (std::getline(file, line)) {
+      while (asys::SystemTools::GetLineFromStream(file, line)) {
         if (line.compare("DrrRenderer_begin") == 0) {
           for (int i = 0; i < camera->childCount(); i++) {
             ModelViewTreeWidgetItem* modelviewItem = dynamic_cast<ModelViewTreeWidgetItem*>(camera->child(i));
@@ -298,7 +299,7 @@ void FilterTreeWidget::loadFilterSettings(int camera, QString filename)
     if (camera) {
       std::ifstream file(filename.toStdString().c_str(), std::ios::in);
       std::string line, key;
-      while (std::getline(file, line)) {
+      while (asys::SystemTools::GetLineFromStream(file, line)) {
         if (line.compare("DrrRenderer_begin") == 0) {
           for (int i = 0; i < camera->childCount(); i++) {
             ModelViewTreeWidgetItem* modelviewItem = dynamic_cast<ModelViewTreeWidgetItem*>(camera->child(i));

--- a/autoscoper/src/ui/FilterTreeWidgetItem.cpp
+++ b/autoscoper/src/ui/FilterTreeWidgetItem.cpp
@@ -66,6 +66,7 @@
 #  include <gpu/opencl/SharpenFilter.hpp>
 #  include <gpu/opencl/GaussianFilter.hpp>
 #endif
+#include <asys/SystemTools.hxx>
 #include <Filter.hpp>
 
 #include <iostream>
@@ -147,8 +148,9 @@ void FilterTreeWidgetItem::save(std::ofstream& file)
 void FilterTreeWidgetItem::load(std::ifstream& file)
 {
   std::string line, key;
-  while (std::getline(file, line) && line.compare("SobelFilter_end") != 0 && line.compare("ContrastFilter_end") != 0
-         && line.compare("GaussianFilter_end") != 0 && line.compare("SharpenFilter_end") != 0) {
+  while (asys::SystemTools::GetLineFromStream(file, line) && line.compare("SobelFilter_end") != 0
+         && line.compare("ContrastFilter_end") != 0 && line.compare("GaussianFilter_end") != 0
+         && line.compare("SharpenFilter_end") != 0) {
     std::istringstream lineStream(line);
     lineStream >> key;
 

--- a/autoscoper/src/ui/ModelViewTreeWidgetItem.cpp
+++ b/autoscoper/src/ui/ModelViewTreeWidgetItem.cpp
@@ -62,6 +62,7 @@
 #include <sstream>
 #include <math.h> /* exp */
 
+#include <asys/SystemTools.hxx>
 #include <View.hpp>
 #if defined(Autoscoper_RENDERING_USE_CUDA_BACKEND)
 #  include <gpu/cuda/RayCaster.hpp>
@@ -126,7 +127,7 @@ void ModelViewTreeWidgetItem::loadSettings(std::ifstream& file)
 {
   std::string line, key;
   if (m_type == 1) {
-    while (std::getline(file, line) && line.compare("DrrRenderer_end") != 0) {
+    while (asys::SystemTools::GetLineFromStream(file, line) && line.compare("DrrRenderer_end") != 0) {
       std::istringstream lineStream(line);
       lineStream >> key;
       if (key.compare("SampleDistance") == 0) {
@@ -159,7 +160,8 @@ void ModelViewTreeWidgetItem::loadFilters(std::ifstream& file)
     }
   }
 
-  while (std::getline(file, line) && line.compare("DrrFilters_end") != 0 && line.compare("RadFilters_end") != 0) {
+  while (asys::SystemTools::GetLineFromStream(file, line) && line.compare("DrrFilters_end") != 0
+         && line.compare("RadFilters_end") != 0) {
     std::istringstream lineStream(line);
     lineStream >> key;
     if (key.compare("SobelFilter_begin") == 0) {

--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(libautoscoper_HEADERS
+  src/asys/SystemTools.hxx
   src/Backtrace.hpp
   src/Camera.hpp
   src/CoordFrame.hpp
@@ -17,6 +18,7 @@ set(libautoscoper_HEADERS
 )
 
 set(libautoscoper_SOURCES
+  src/asys/SystemTools.cxx
   src/Backtrace.cpp
   src/Camera.cpp
   src/CoordFrame.cpp

--- a/libautoscoper/src/Camera.cpp
+++ b/libautoscoper/src/Camera.cpp
@@ -54,41 +54,9 @@
 #include <json/json.h>
 
 #include "Camera.hpp"
+#include "asys/SystemTools.hxx"
 
 namespace xromm {
-std::istream& safeGetline(std::istream& is, std::string& t)
-{
-  t.clear();
-
-  // The characters in the stream are read one-by-one using a std::streambuf.
-  // That is faster than reading them one-by-one using the std::istream.
-  // Code that uses streambuf this way must be guarded by a sentry object.
-  // The sentry object performs various tasks,
-  // such as thread synchronization and updating the stream state.
-
-  std::istream::sentry se(is, true);
-  std::streambuf* sb = is.rdbuf();
-
-  for (;;) {
-    int c = sb->sbumpc();
-    switch (c) {
-      case '\n':
-        return is;
-      case '\r':
-        if (sb->sgetc() == '\n')
-          sb->sbumpc();
-        return is;
-      case EOF:
-        // Also handle the case when the last line has no line ending
-        if (t.empty()) {
-          is.setstate(std::ios::eofbit);
-        }
-        return is;
-      default:
-        t += (char)c;
-    }
-  }
-}
 
 std::string mayaCamReadingError(const std::string& version,
                                 int line,
@@ -159,7 +127,7 @@ Camera::Camera(const std::string& mayacam)
     }
 
     std::string csv_line;
-    safeGetline(file, csv_line);
+    asys::SystemTools::GetLineFromStream(file, csv_line);
     file.close();
     if (csv_line.compare("image size") == 0) {
       loadMayaCam2(mayacam);
@@ -178,7 +146,7 @@ void Camera::loadMayaCam1(const std::string& mayacam)
   std::string csv_line, csv_val;
   int line_count = 0;
 
-  for (int i = 0; i < 5 && safeGetline(file, csv_line); ++i) {
+  for (int i = 0; i < 5 && asys::SystemTools::GetLineFromStream(file, csv_line); ++i) {
     int read_count = 0;
     std::istringstream csv_line_stream(csv_line);
     for (int j = 0; j < 3 && std::getline(csv_line_stream, csv_val, ','); ++j) {
@@ -274,7 +242,7 @@ void Camera::loadMayaCam2(const std::string& mayacam)
 
   std::fstream file(mayacam.c_str(), std::ios::in);
   std::string csv_line, csv_val;
-  for (int i = 0; i < 17 && safeGetline(file, csv_line); ++i) {
+  for (int i = 0; i < 17 && asys::SystemTools::GetLineFromStream(file, csv_line); ++i) {
     std::istringstream csv_line_stream(csv_line);
 
     switch (i) {

--- a/libautoscoper/src/Trial.cpp
+++ b/libautoscoper/src/Trial.cpp
@@ -49,6 +49,7 @@
 #include <sstream>
 #include <stdexcept>
 
+#include "asys/SystemTools.hxx"
 #include "Video.hpp"
 #include "Volume.hpp"
 #include "Camera.hpp"
@@ -196,7 +197,7 @@ void Trial::parse(std::ifstream& file,
 {
 
   std::string line, key, value;
-  while (std::getline(file, line)) {
+  while (asys::SystemTools::GetLineFromStream(file, line)) {
 
     // Skip blank lines and commented lines.
     if (line.size() == 0 || line[0] == '\n' || line[0] == '#') {
@@ -206,38 +207,31 @@ void Trial::parse(std::ifstream& file,
     std::istringstream lineStream(line);
     std::getline(lineStream, key, ' ');
     if (key.compare("mayaCam_csv") == 0) {
-      std::getline(lineStream, value);
-      trimLineEndings(value);
+      asys::SystemTools::GetLineFromStream(lineStream, value);
       convertToUnixSlashes(value);
       mayaCams.push_back(value);
     } else if (key.compare("CameraRootDir") == 0) {
-      std::getline(lineStream, value);
-      trimLineEndings(value);
+      asys::SystemTools::GetLineFromStream(lineStream, value);
       convertToUnixSlashes(value);
       camRootDirs.push_back(value);
     } else if (key.compare("VolumeFile") == 0) {
-      std::getline(lineStream, value);
-      trimLineEndings(value);
+      asys::SystemTools::GetLineFromStream(lineStream, value);
       convertToUnixSlashes(value);
       volumeFiles.push_back(value);
     } else if (key.compare("VolumeFlip") == 0) {
-      std::getline(lineStream, value);
-      trimLineEndings(value);
+      asys::SystemTools::GetLineFromStream(lineStream, value);
       volumeFlips.push_back(value);
     } else if (key.compare("VoxelSize") == 0) {
-      std::getline(lineStream, value);
-      trimLineEndings(value);
+      asys::SystemTools::GetLineFromStream(lineStream, value);
       voxelSizes.push_back(value);
     } else if (key.compare("RenderResolution") == 0) {
-      std::getline(lineStream, value);
-      trimLineEndings(value);
+      asys::SystemTools::GetLineFromStream(lineStream, value);
       renderResolution.push_back(value);
     } else if (key.compare("OptimizationOffsets") == 0) {
-      std::getline(lineStream, value);
+      asys::SystemTools::GetLineFromStream(lineStream, value);
       optimizationOffsets.push_back(value);
     } else if (key.compare("Version") == 0) {
-      std::getline(lineStream, value);
-      trimLineEndings(value);
+      asys::SystemTools::GetLineFromStream(lineStream, value);
       parseVersion(value, version);
       continue;
     }
@@ -252,12 +246,6 @@ void Trial::parseVersion(const std::string& text, std::vector<int>& version)
     std::getline(versionStream, versionNumber, '.');
     version[idx] = std::atoi(versionNumber.c_str());
   }
-}
-
-void Trial::trimLineEndings(std::string& str)
-{
-  str.erase(std::remove(str.begin(), str.end(), '\r'), str.end());
-  str.erase(std::remove(str.begin(), str.end(), '\n'), str.end());
 }
 
 void Trial::validate(const std::vector<std::string>& mayaCams,

--- a/libautoscoper/src/asys/SystemTools.cxx
+++ b/libautoscoper/src/asys/SystemTools.cxx
@@ -1,0 +1,52 @@
+
+
+#include "asys/SystemTools.hxx"
+
+#include <fstream>
+
+namespace asys {
+
+// Convenience function around std::getline which removes a trailing carriage
+// return and can truncate the buffer as needed.  Returns true
+// if any data were read before the end-of-file was reached.
+bool SystemTools::GetLineFromStream(std::istream& is,
+                                    std::string& line,
+                                    bool* has_newline /* = 0 */,
+                                    std::string::size_type sizeLimit /* = std::string::npos */)
+{
+  // Start with an empty line.
+  line = "";
+
+  // Early short circuit return if stream is no good. Just return
+  // false and the empty line. (Probably means caller tried to
+  // create a file stream with a non-existent file name...)
+  //
+  if (!is) {
+    if (has_newline) {
+      *has_newline = false;
+    }
+    return false;
+  }
+
+  std::getline(is, line);
+  bool haveData = !line.empty() || !is.eof();
+  if (!line.empty()) {
+    // Avoid storing a carriage return character.
+    if (line.back() == '\r') {
+      line.resize(line.size() - 1);
+    }
+
+    // if we read too much then truncate the buffer
+    if (sizeLimit != std::string::npos && line.size() > sizeLimit) {
+      line.resize(sizeLimit);
+    }
+  }
+
+  // Return the results.
+  if (has_newline) {
+    *has_newline = !is.eof();
+  }
+  return haveData;
+}
+
+} // namespace asys

--- a/libautoscoper/src/asys/SystemTools.hxx
+++ b/libautoscoper/src/asys/SystemTools.hxx
@@ -1,0 +1,39 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing#kwsys for details.  */
+#ifndef asys_SystemTools_hxx
+#define asys_SystemTools_hxx
+
+// Adapted from https://gitlab.kitware.com/utils/kwsys
+// "asys" is used as namespace and is short for "Autoscoper SystemTools"
+
+#include <iosfwd>
+#include <string>
+
+namespace asys {
+
+/** \class SystemTools
+ * \brief A collection of useful platform-independent system functions.
+ */
+class SystemTools
+{
+public:
+  /** -----------------------------------------------------------------
+   *               Filename Manipulation Routines
+   *  -----------------------------------------------------------------
+   */
+
+  /**
+   * Read line from file. Make sure to read a full line and truncates it if
+   * requested via sizeLimit. Returns true if any data were read before the
+   * end-of-file was reached. If the has_newline argument is specified, it will
+   * be true when the line read had a newline character.
+   */
+  static bool GetLineFromStream(std::istream& istr,
+                                std::string& line,
+                                bool* has_newline = nullptr,
+                                std::string::size_type sizeLimit = std::string::npos);
+};
+
+} // namespace asys
+
+#endif


### PR DESCRIPTION
This commit addresses a bug where files saved on Windows platforms using `\r\n` line endings were not correctly read on Unix platforms using `\n`. To resolve this issue, the commit introduces the function `GetLineFromStream()` to consistently read lines from text files independent of the line ending conventions.

Additionally, this commit removes the complex `safeGetline` function, which aimed to achieve similar behavior. Originally sourced from Stack Overflow[^1] and introduced in commit 243123c ("Added support for MayaCam version 2", dated 2018-01-11).

[^1]: https://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf/6089413#6089413