### PR TITLE
BUG: Fix rendering of 3D texture associated with the CUDA backend

### DIFF
--- a/libautoscoper/src/gpu/cuda/cutil/cutil_create_tex_obj.h
+++ b/libautoscoper/src/gpu/cuda/cutil/cutil_create_tex_obj.h
@@ -19,6 +19,7 @@ inline cudaTextureObject_t createTexureObjectFromArray(cudaArray* arr, cudaTextu
   texDesc.filterMode = cudaFilterModeLinear;
   texDesc.addressMode[0] = cudaAddressModeClamp;
   texDesc.addressMode[1] = cudaAddressModeClamp;
+  texDesc.addressMode[2] = cudaAddressModeClamp;
   texDesc.readMode = readMode;
 
   cudaTextureObject_t tex = 0;


### PR DESCRIPTION
Fix #264 by addressing a regression introduced in 866a5d2 ("ENH: Add support for 16 and 32-bit radiograph images", 2023-01-13)

This ensures the texture clamping mode is consistently set across all dimensions.