### PR TITLE
BUG: Fix out of bounds NCC value in viewport clipping

### DIFF
--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -582,7 +582,7 @@ std::vector<double> Tracker::trackFrame(unsigned int volumeID, double* xyzypr) c
     double viewport[4];
     if (!this->calculate_viewport(modelview, *views_[i]->camera(), viewport)) {
       std::cerr << "Tracker::trackFrame(): Volume " << volumeID << " is not in view of camera " << i << std::endl;
-      correlations.push_back(0.0);
+      correlations.push_back(9999.0);
       continue;
     }
 


### PR DESCRIPTION
Regression introduced in 4704f9b ("BUG: Clip bounds of DRR projection to the bounds of the radiograph", 2023-11-01).
    
Previously whenever a volume was outside the bounds of a radiograph image the NCC value would be appended as 0. In this case it is possible that the PSO could try to move the volume to be outside the bounds of all the radiographs.

Related pull requests:
* https://github.com/BrownBiomechanics/Autoscoper/pull/230