### PR TITLE
BUG: Fix edge cases in Slerp

### DIFF
--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -952,6 +952,12 @@ bool Tracker::calculate_viewport(const CoordFrame& modelview, const Camera& came
     return false;
   }
 
+  // Check if min_max is unchanged from the initial values
+  if (min_max[0] == 1.0 && min_max[1] == 1.0 && min_max[2] == -1.0 && min_max[3] == -1.0) {
+    // This usually means that the rotation was all NaN
+    return false;
+  }
+
   // clip min_max to rad_min_max_film
   if (min_max[0] < rad_min_max_film[0]) {
     min_max[0] = rad_min_max_film[0];

--- a/math/Quaternion.hpp
+++ b/math/Quaternion.hpp
@@ -379,6 +379,10 @@ struct Quat
 
   friend Quat slerp(const Quat& p, const Quat& q, const T& t)
   {
+    if (t < std::numeric_limits<T>::epsilon())
+      return p;
+    if (t > T(1) - std::numeric_limits<T>::epsilon())
+      return q;
     T cosRad = dot(unit(p), unit(q));
     T rad = acos(cosRad);
     if (rad < std::numeric_limits<T>::epsilon()) {


### PR DESCRIPTION
Closes #275 
Regression initially introduced in 6b7ad8e. Slerp interpolation fails in some cases when t == 0 or t == 1