### PR TITLE
Pivot alignment and centering

### DIFF
--- a/Documentation/shortcuts.md
+++ b/Documentation/shortcuts.md
@@ -21,6 +21,8 @@ This is a list of all the shortcuts that are available in the current version of
 | `D` | Switch to move volume pivot mode |
 | `H` | Toggle visibility of all volumes |
 | `L` | Toggle visibility of all Radiographs |
+| `O` | Snap the manipulator axes back to the global axes |
+| `P` | Snap the manipulator position back to the center of the volume |
 | `+` / `=` | Increase size of manipulator |
 | `-` | Decrease size of manipulator |
 

--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -2447,7 +2447,7 @@ void AutoscoperMainWindow::key_p_pressed()
   // The translation center is the relative position of the center of the volume to the corner coordinate.
   // Since this describes the movement from the corner to the center we transform the inverse of this point
   // by the volumes R and t to get the position of the manipulator in world space.
-  Vec3f trans_center = tracker->getVolumeDescription(-1)->transCenterVec();
+  Vec3f trans_center = Vec3f(tracker->getVolumeDescription(-1)->transCenter());
   Vec3f vol_center_world = vol_world.transform_vector(-trans_center);
 
   // Update the position of the manipulator to the transformed point

--- a/autoscoper/src/ui/AutoscoperMainWindow.h
+++ b/autoscoper/src/ui/AutoscoperMainWindow.h
@@ -335,6 +335,7 @@ public slots:
   void key_k_pressed();
   // void key_r_pressed();
   void key_p_pressed();
+  void key_o_pressed();
   void key_c_pressed();
   void key_plus_pressed();
   void key_equal_pressed();

--- a/autoscoper/src/ui/AutoscoperMainWindow.h
+++ b/autoscoper/src/ui/AutoscoperMainWindow.h
@@ -334,7 +334,7 @@ public slots:
   void key_j_pressed();
   void key_k_pressed();
   // void key_r_pressed();
-  // void key_p_pressed();
+  void key_p_pressed();
   void key_c_pressed();
   void key_plus_pressed();
   void key_equal_pressed();

--- a/libautoscoper/src/CoordFrame.cpp
+++ b/libautoscoper/src/CoordFrame.cpp
@@ -325,6 +325,13 @@ void CoordFrame::translate(const double* v)
   translation_[2] += v[2];
 }
 
+void CoordFrame::set_translation(const Vec3f& t)
+{
+  translation_[0] = t.x;
+  translation_[1] = t.y;
+  translation_[2] = t.z;
+}
+
 CoordFrame CoordFrame::inverse() const
 {
   // clang-format off
@@ -376,6 +383,37 @@ void CoordFrame::vector_to_world_space(const double* p, double* q) const
          rotation_[5] * p[1] +
          rotation_[8] * p[2];
   // clang-format on
+}
+
+Vec3f CoordFrame::rotate_vector(const Vec3f& p)
+{
+  Vec3f q;
+  // clang-format off
+  q.x = rotation_[0] * p.x +
+        rotation_[3] * p.y +
+        rotation_[6] * p.z;
+  q.y = rotation_[1] * p.x +
+        rotation_[4] * p.y +
+        rotation_[7] * p.z;
+  q.z = rotation_[2] * p.x +
+        rotation_[5] * p.y +
+        rotation_[8] * p.z;
+  // clang-format on
+  return q;
+}
+
+Vec3f CoordFrame::translate_vector(const Vec3f& p)
+{
+  Vec3f q;
+  q.x = p.x + translation_[0];
+  q.y = p.y + translation_[1];
+  q.z = p.z + translation_[2];
+  return q;
+}
+
+Vec3f CoordFrame::transform_vector(const Vec3f& p)
+{
+  return translate_vector(rotate_vector(p));
 }
 
 CoordFrame CoordFrame::linear_extrap(const CoordFrame& x) const

--- a/libautoscoper/src/CoordFrame.hpp
+++ b/libautoscoper/src/CoordFrame.hpp
@@ -43,6 +43,7 @@
 #define XROMM_COORD_FRAME_HPP
 
 #include <string>
+#include <Vector.hpp>
 
 namespace xromm {
 
@@ -79,6 +80,8 @@ public:
 
   void translate(const double* v);
 
+  void set_translation(const Vec3f& t);
+
   void rotate(const double* v, double angle);
 
   CoordFrame inverse() const;
@@ -86,6 +89,12 @@ public:
   void point_to_world_space(const double* p, double* q) const;
 
   void vector_to_world_space(const double* p, double* q) const;
+
+  Vec3f rotate_vector(const Vec3f& p);
+
+  Vec3f translate_vector(const Vec3f& p);
+
+  Vec3f transform_vector(const Vec3f& p);
 
   CoordFrame linear_extrap(const CoordFrame& x2) const;
 

--- a/libautoscoper/src/Tracker.cpp
+++ b/libautoscoper/src/Tracker.cpp
@@ -1033,4 +1033,12 @@ void Tracker::getFullDRR(unsigned int volumeID) const
   }
 }
 
+gpu::VolumeDescription* Tracker::getVolumeDescription(const int& index)
+{
+  if (index == -1) {
+    return volumeDescription_[trial()->current_volume];
+  }
+  return volumeDescription_[index];
+}
+
 } // namespace xromm

--- a/libautoscoper/src/Tracker.hpp
+++ b/libautoscoper/src/Tracker.hpp
@@ -155,6 +155,7 @@ public:
   // std::vector<double> trackImplantFrame(unsigned int volumeID, double * xyzypr) const;
 
   void getFullDRR(unsigned int volumeID) const;
+  gpu::VolumeDescription* getVolumeDescription(const int& index);
 
 private:
   bool calculate_viewport(const CoordFrame& modelview, const Camera& camera, double* viewport) const;

--- a/libautoscoper/src/VolumeDescription.hpp
+++ b/libautoscoper/src/VolumeDescription.hpp
@@ -48,6 +48,7 @@ typedef cudaArray Image;
 #elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #  include "gpu/opencl/OpenCL.hpp"
 #endif
+#include "Vector.hpp"
 
 namespace xromm {
 class Volume;
@@ -68,6 +69,8 @@ public:
   const float* invScale() const { return invScale_; }
   const float* invTrans() const { return invTrans_; }
   const double* transCenter() const { return transCenter_; }
+  Vec3f transCenterVec() { return Vec3f(transCenter_); }
+
   float minValue() const { return minValue_; }
   float maxValue() const { return maxValue_; }
 

--- a/libautoscoper/src/VolumeDescription.hpp
+++ b/libautoscoper/src/VolumeDescription.hpp
@@ -48,7 +48,6 @@ typedef cudaArray Image;
 #elif defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
 #  include "gpu/opencl/OpenCL.hpp"
 #endif
-#include "Vector.hpp"
 
 namespace xromm {
 class Volume;
@@ -69,8 +68,6 @@ public:
   const float* invScale() const { return invScale_; }
   const float* invTrans() const { return invTrans_; }
   const double* transCenter() const { return transCenter_; }
-  Vec3f transCenterVec() { return Vec3f(transCenter_); }
-
   float minValue() const { return minValue_; }
   float maxValue() const { return maxValue_; }
 


### PR DESCRIPTION
* Closes #284 
* Closes #286 
* Adds shortcut `O` to align the manipulator axes to the global axes
![align_pivot](https://github.com/user-attachments/assets/432a33b1-04f4-4b60-a6c1-f8a3ba6b8fd0)
* Adds shortcut `P` to snap the pivot back to the center of the volume
![center_pivot](https://github.com/user-attachments/assets/2bd1da86-16e4-4430-b6f0-d96849ee35e3)
