### PR TITLE
DOC: Fix ill-formatted links and missing image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,5 +133,5 @@ is the checklist:
 *The initial version of these guidelines is adapted from [3D Slicer guidelines](https://slicer.readthedocs.io/en/latest/developer_guide/contributing.html?highlight=contributing#decision-making-process)*
 
 
-[slicer-forum]: https://discourse.slicer.org/c/community/slicerautoscoperm/30
-[slicer-issues]: https://github.com/BrownBiomechanics/Autoscoper/issues
+[autoscoper-forum]: https://discourse.slicer.org/c/community/slicerautoscoperm/30
+[autoscoper-issues]: https://github.com/BrownBiomechanics/Autoscoper/issues

--- a/Documentation/tutorials/pre-processing-module.md
+++ b/Documentation/tutorials/pre-processing-module.md
@@ -22,7 +22,7 @@ Before diving into pre-processing, ensure that you have already loaded the data 
 
 To access the Pre-Processing module, open the AutoscoperM module located in the `Tracking` category. Next, navigate to the second tab labeled `Autoscoper Pre-Processing`.
 
-![Pre-Processing Module UI Overview](https://github.com/BrownBiomechanics/Autoscoper/releases/download/docs-resources/prePro_uiOverview.png)
+![Pre-Processing Module UI Overview](https://github.com/BrownBiomechanics/Autoscoper/releases/download/docs-resources/prePro_overview.png)
 
 ## General Inputs
 


### PR DESCRIPTION
Small fixes to various markdown bugs across the SlicerAutoscoperM docs.

Namely, the image included in the [pre-processing module](https://autoscoper.readthedocs.io/en/latest/tutorials/pre-processing-module.html#accessing-the-pre-processing-module) section of the tutorial was missing due to a broken link
![image](https://github.com/user-attachments/assets/8d8880db-9687-4290-9cda-bb2341a8063c)
and the links for the Autoscoper forum and issue tracker were not being formatted correctly in multiple places on the [Contributing page](https://autoscoper.readthedocs.io/en/latest/developer-guide/contributing.html)
![image](https://github.com/user-attachments/assets/3e5a2969-ab0d-4188-a778-0b2ce6f8a5cc)
