### PR TITLE
DOC: Deprecate camera calibration file spec and remove VRG references

### DIFF
--- a/Documentation/file-specifications/camera-calibration.md
+++ b/Documentation/file-specifications/camera-calibration.md
@@ -2,6 +2,10 @@
 
 ## VTKCam 1.0
 
+```{important} Deprecated
+This file specification is no longer supported. The VRG generation functionality was removed in [BrownBiomechanics/SlicerAutoscoperM#140](https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/140). Please refer to the updated workflows and documentation for alternative solutions.
+```
+
 ### Overview
 
 The camera calibration file is a yaml and contains all of the information to load a camera into Autoscoper. The file is organized with key value pairs.

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -55,4 +55,3 @@ This section defines terms that are commonly used by Autoscoper and SlicerAutosc
 * **Sequential 3D CT**: A series of 3D CT scans acquired from the same region of interest (such as a joint or limb) in different positions. Using the Sequences module, these independent volumes can be visualized and processed together as a series.
 * **TFM**: An ITK transformation file with the extension `.tfm`.
 * **TRA**: A transform file with the extension `.tra` exported by Autoscoper. It contains a Nx16 transformation matrix of rigid body kinematics. Each one of the N lines represents a frame of BVR data optimized by Autoscoper. The TRA transforms can be applied to AUT models to visualized 3D motion of the rigid body and calculate motion.
-* **Virtually Generated Radiograph (VRG)**: Synthetic radiograph generated from 3D CT using synthetic camera models.

--- a/Documentation/tutorials/pre-processing-module.md
+++ b/Documentation/tutorials/pre-processing-module.md
@@ -7,8 +7,7 @@ Currently, the module supports the following tasks:
 - Segmentation generation or loading
 - Partial volume cropping and extraction
 
-In the future, we will add support for the following tasks
-- Virtual Radiograph (VRG) generation
+In the future, we will add support for the following tasks:
 - Config file generation
 ```
 


### PR DESCRIPTION
Updates the documentation to reflect the removal of the VRG generation functionality in https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/140, as requested by https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/132.

See the docs for this branch [here](https://autoscoper--307.org.readthedocs.build/en/307/file-specifications/camera-calibration.html)