### PR TITLE
DOC: Update documentation for Pre-Processing config generation

### DIFF
--- a/Documentation/file-specifications/config.md
+++ b/Documentation/file-specifications/config.md
@@ -1,6 +1,6 @@
 # Configuration File Format
 
-(version-1-1)=
+(config-file-format-version-1-1)=
 ## Version 1.1
 
 ### Overview

--- a/Documentation/file-specifications/config.md
+++ b/Documentation/file-specifications/config.md
@@ -1,5 +1,6 @@
 # Configuration File Format
 
+(version-1-1)=
 ## Version 1.1
 
 ### Overview

--- a/Documentation/tutorials/pre-processing-module.md
+++ b/Documentation/tutorials/pre-processing-module.md
@@ -6,8 +6,6 @@ This module is currently under development, and details are subject to change wi
 Currently, the module supports the following tasks:
 - Segmentation generation or loading
 - Partial volume cropping and extraction
-
-In the future, we will add support for the following tasks:
 - Config file generation
 ```
 
@@ -21,6 +19,7 @@ Before diving into pre-processing, ensure that you have already loaded the data 
 
 To access the Pre-Processing module, open the AutoscoperM module located in the `Tracking` category. Next, navigate to the second tab labeled `Autoscoper Pre-Processing`.
 
+<!-- TODO: update this image -->
 ![Pre-Processing Module UI Overview](https://github.com/BrownBiomechanics/Autoscoper/releases/download/docs-resources/prePro_overview.png)
 
 ## General Inputs
@@ -35,12 +34,12 @@ The Pre-Processing module requires two inputs:
 You have three options for segmentations:
 
 * Auto-generate: Automatically generates segmentations based on the volume node.
-* Load: Allows you to load existing segmentations from a directory.
+* Load: Allows you to load segmentations from existing STL files in a directory.
 * Use Slicer to create new segmentation: Utilizes the built-in Slicer tools for segmentation. For more information see the [Image Segmentation](https://slicer.readthedocs.io/en/latest/user_guide/image_segmentation.html) page of the Slicer documentation.
 
 ### Auto-Generated Segmentations
 
-To auto-generate a set of segments for your CT data, select the `Automatic Segmentation` option and specify a threshold value. The default value is 700 Hounsfield Units (HU), but this value may vary depending on your CT data.
+To auto-generate a set of segments for your CT data, select the `Automatic Segmentation` option and specify a threshold value. The default value is 700 Hounsfield Units (HU), but a different value may be more ideal, depending on your CT data.
 
 To determine an appropriate threshold value, use the data probe (located in the bottom left corner of the Slicer UI) to explore the volume. The data probe displays the HU value of the voxel under the mouse pointer. Determine the average HU value of the exterior surface of the bone and the average HU value of the flesh and muscle. The threshold value should be high enough to exclude the flesh and muscle, but low enough to include the exterior surface of the bone. Do not worry about the interior of the bone, the auto segmentation will fill in the interior of the bone.
 
@@ -62,7 +61,7 @@ Switching to the `Data` module allows you to view and manage the segmentations. 
 
 ### Load Segmentations
 
-To load existing segmentations, select the `Batch Load from File` option and specify the directory containing the segmentations. The directory should contain segmentation files in one of the following formats:
+To load existing segmentations, select the `Segmentation from Model` option and specify the directory containing the segmentations. The directory should contain segmentation files in one of the following formats:
 
 ```
 *.seg.nrrd
@@ -73,12 +72,16 @@ To load existing segmentations, select the `Batch Load from File` option and spe
 *.stl
 ```
 
-After selecting the directory, click the `Generate Segmentations` button.
+After selecting the directory, click the `Import Models` button.
 
-The loaded segmentations will appear as individual segments within a single segmentation node.
+The loaded segmentations will appear in Slicer as individual segments within a single segmentation node.
 
 ```{warning}
 Segmentations loaded using this method may require a transformation to align them with the volume node. For more information on applying transformations, refer to the [Transforms](https://slicer.readthedocs.io/en/latest/user_guide/modules/transforms.html) page in the Slicer documentation.
+```
+
+```{tip}
+Cropping the input volume to a smaller region of interest (ROI) can help reduce the computation time and the amount of irrelevant output generated. For more details on volume cropping, see the [Slicer documentation](https://slicer.readthedocs.io/en/latest/user_guide/modules/cropvolume.html)
 ```
 
 ## Partial Volume Cropping and Extraction
@@ -96,3 +99,34 @@ Output Directory
 |   |-- ...
 |   |-- Segment_n.tif
 ```
+
+```{warning}
+Partial Volumes generated using this method must be loaded into Slicer via the `Load Partial Volumes` button, rather than through the `Add Data` widget or dragging and dropping the files. This is because the generated TIFF files do not inherently store spatial information. As a result, when loaded into Slicer, the application will assign default spatial direction information, which may not match your data. To ensure the partial volumes retain the correct spatial information, be sure to load them via the Autoscoper Pre-Processing module with the appropriate input volume selected.
+```
+
+## Configuration File Generation
+
+The `Generate Config` section of the Pre-Processing module an alternative way to create an [Autoscoper configuration file](../file-specifications/config.md).For more information on generating a configuration file directly within the Autoscoper application, see the section on [](./custom-data.md#creating-a-configuration-file).
+
+The inputs you provide in this section follow the configuration file format specified in [version 1.1](../file-specifications/config.md#version-1-1).
+
+
+### Creating a Configuration File
+
+To begin, you will first need to specify the filename for the configuration file you wish to generate in the text field labeled `Config Trial Name`.
+
+Next, you will select the camera calibration files and radiograph subdirectories. These paths correspond to the `mayaCam_csv` and `CameraRootDir` file format keys, respectively. Note that the order in which radiograph subdirectories are specified must match the order of the camera calibration files to ensure the correct camera is loaded.
+
+To select the files, click the `Populate From Camera Subdirectory` button to load the contents of the `Camera Subdirectory` (as specified in the `Default Subdirectories` section) into the left-hand list. Similarly, click the `Populate From Radiographs Subdirectory` button to load the contents of the `Radiograph Subdirectory` into the left-hand list.
+
+Once the directories are populated, you can select the files you wish to include in your configuration file. For each file, check the box to its left, and then click the green right arrow button. This will add the item to the list on the right. The order of items in the right-hand list reflects the order in which they will appear in the configuration file. It is crucial that the number of camera calibration files and radiograph subdirectories match, and that the items in both lists correspond pairwise (e.g., the first camera calibration file should correspond to the first radiograph subdirectory, the second camera calibration file to the second radiograph subdirectory, and so on).
+
+If you wish to adjust the order of selected items, you can remove them from the right-hand list by clicking the `Delete` button next to each item. You and then re-add them in the desired order.
+
+<!-- TODO: insert screenshot of path specification here -->
+
+For selecting partial volume files, the process is similar but without the need to specify an order. Click the `Populate from Volume Subdirectory button` to load all available partial volume files from the `Partial Volume Subdirectory`. From there, you can check the files you want to include in the configuration file.
+
+The remaining parameters to configure are relatively straightforward: the optimization offsets, made of six decimal values; the volume flip, which can be enabled or disabled for each of the axes; the render resolution, made of two integer values (width and height); the voxel size, made of three decimal values, set automatically according to the selected input volume.
+
+When you are done setting the necessary parameters, click the `Generate Config File` button at the bottom of this section. This will generate the configuration file and write it to the output directory specified in the `Output Directory` field at the top of the Autoscoper Pre-Processing tab.

--- a/Documentation/tutorials/pre-processing-module.md
+++ b/Documentation/tutorials/pre-processing-module.md
@@ -19,7 +19,6 @@ Before diving into pre-processing, ensure that you have already loaded the data 
 
 To access the Pre-Processing module, open the AutoscoperM module located in the `Tracking` category. Next, navigate to the second tab labeled `Autoscoper Pre-Processing`.
 
-<!-- TODO: update this image -->
 ![Pre-Processing Module UI Overview](https://github.com/BrownBiomechanics/Autoscoper/releases/download/docs-resources/prePro_overview.png)
 
 ## General Inputs
@@ -123,7 +122,7 @@ Once the directories are populated, you can select the files you wish to include
 
 If you wish to adjust the order of selected items, you can remove them from the right-hand list by clicking the `Delete` button next to each item. You and then re-add them in the desired order.
 
-<!-- TODO: insert screenshot of path specification here -->
+![Configuration File Path Selection](https://github.com/BrownBiomechanics/Autoscoper/releases/download/docs-resources/prePro_configPathSelection.gif)
 
 For selecting partial volume files, the process is similar but without the need to specify an order. Click the `Populate from Volume Subdirectory button` to load all available partial volume files from the `Partial Volume Subdirectory`. From there, you can check the files you want to include in the configuration file.
 

--- a/Documentation/tutorials/pre-processing-module.md
+++ b/Documentation/tutorials/pre-processing-module.md
@@ -108,7 +108,7 @@ Partial Volumes generated using this method must be loaded into Slicer via the `
 
 The `Generate Config` section of the Pre-Processing module an alternative way to create an [Autoscoper configuration file](../file-specifications/config.md).For more information on generating a configuration file directly within the Autoscoper application, see the section on [](./custom-data.md#creating-a-configuration-file).
 
-The inputs you provide in this section follow the configuration file format specified in [version 1.1](../file-specifications/config.md#version-1-1).
+The inputs you provide in this section follow the configuration file format specified in {ref}`config-file-format-version-1-1`.
 
 
 ### Creating a Configuration File


### PR DESCRIPTION
Updates to the documentation page for the Pre-Processing module to reflect the changes in https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/141
Review the changes [here](https://autoscoper--308.org.readthedocs.build/en/308/tutorials/pre-processing-module.html).