### PR TITLE
ENH: Socket port to default

### DIFF
--- a/autoscoper/src/main.cpp
+++ b/autoscoper/src/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
 
   if (argc <= 1) {
     AutoscoperMainWindow* widget = new AutoscoperMainWindow();
-    Socket* socket = new Socket(widget, 30007);
+    Socket* socket = new Socket(widget, 0);
     widget->show();
     int ret = app.exec();
     delete socket;
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
   } else {
     fprintf(stderr, "Start Batch %s\n", argv[1]);
     AutoscoperMainWindow* widget = new AutoscoperMainWindow(true);
-    Socket* socket = new Socket(widget, 30007);
+    Socket* socket = new Socket(widget, 0);
     widget->runBatch(argv[1], true);
     delete socket;
   }


### PR DESCRIPTION
Possible modification to allow automatic port chosen in constructor. Multiple instances

According to https://doc.qt.io/qt-6/qtcpserver.html

 (bool QTcpServer::listen(const [QHostAddress](https://doc.qt.io/qt-6/qhostaddress.html) &address = QHostAddress::Any, [quint16](https://doc.qt.io/qt-6/qttypes.html#quint16-typedef) port = 0)
Tells the server to listen for incoming connections on address address and port port. If port is 0, a port is chosen automatically. If address is [QHostAddress::Any](https://doc.qt.io/qt-6/qhostaddress.html#SpecialAddress-enum), the server will listen on all network interfaces.)

#309 

May create ambiguity (does the socket created in each instance retain 1:1 listening to constructed Socket )?