### PR TITLE
Fix icd segfault

### DIFF
--- a/autoscoper/src/ui/AutoscoperMainWindow.cpp
+++ b/autoscoper/src/ui/AutoscoperMainWindow.cpp
@@ -147,11 +147,11 @@ AutoscoperMainWindow::AutoscoperMainWindow(bool skipGpuDevice, QWidget* parent)
 #if defined(Autoscoper_RENDERING_USE_OpenCL_BACKEND)
   if (!skipGpuDevice) {
     OpenCLPlatformSelectDialog* dialog = new OpenCLPlatformSelectDialog(this);
-    if (dialog->getNumberPlatforms() > 1)
+    auto numberOfPlatforms = dialog->getNumberPlatforms();
+    if (numberOfPlatforms > 1)
       dialog->exec();
-    else {
+    else if (numberOfPlatforms > 0)
       xromm::gpu::setUsedPlatform(0);
-    }
     delete dialog;
   }
 #endif

--- a/libautoscoper/src/Video.cpp
+++ b/libautoscoper/src/Video.cpp
@@ -39,6 +39,7 @@
 /// \file Video.cpp
 /// \author Andy Loomis, Benjamin Knorlein
 
+#include <limits>
 #include <cstring>
 #include <algorithm>
 #include <iostream>


### PR DESCRIPTION
If OpenCL ICD finds 0 suitable platforms, then `xromm::gpu::setUsedPlatform(0)` is called which segfaults. This adds a separate check so that, in that case, OpenCL is not used (the same behavior as if `skipGpuDevice=true`.

Also, the only thing stopping compilation on GCC/Linux was a missing `#include <limits>` in `Video.cpp`, so I added that.

---

This ought to fix the issues described in https://discourse.slicer.org/t/autoscoper-crashes-when-trying-to-load/45790 and https://discourse.slicer.org/t/trouble-opening-the-load-data/44330, since (best I can tell) this segfault would occur when the only platforms are Intel, which is the case for all three cases described in those threads. Then the autoscoper instance never launches and the connection fails.

Should fix #304.

---

Once this is merged, I think we just to update the hash in https://github.com/BrownBiomechanics/SlicerAutoscoperM/blob/main/SuperBuild/External_Autoscoper.cmake#L38 and let the nightly extension build handle the rest.

cc @bpaniagua.