### PR TITLE
COMP: Fix build with VTK 9.6

### DIFF
--- a/autoscoper/src/ui/GLWidget.h
+++ b/autoscoper/src/ui/GLWidget.h
@@ -47,10 +47,10 @@
 
 // OpenGL error checking
 #if defined GLDEBUG
-#  define CALL_GL(exp)                                                             \
-    do {                                                                           \
-      exp;                                                                         \
-      if (glGetError() != GL_NO_ERROR)                                             \
+#  define CALL_GL(exp)                                                                       \
+    do {                                                                                     \
+      exp;                                                                                   \
+      if (glGetError() != GL_NO_ERROR)                                                       \
         std::cerr << "Error in OpenGL call at " << __FILE__ << ':' << __LINE__ << std::endl; \
     } while (0)
 #else

--- a/autoscoper/src/ui/GLWidget.h
+++ b/autoscoper/src/ui/GLWidget.h
@@ -43,6 +43,7 @@
 #define GLWIDGET_H
 
 #include <QOpenGLWidget>
+#include <iostream>
 
 // OpenGL error checking
 #if defined GLDEBUG
@@ -50,7 +51,7 @@
     do {                                                                           \
       exp;                                                                         \
       if (glGetError() != GL_NO_ERROR)                                             \
-        cerr << "Error in OpenGL call at " << __FILE__ << ':' << __LINE__ << endl; \
+        std::cerr << "Error in OpenGL call at " << __FILE__ << ':' << __LINE__ << std::endl; \
     } while (0)
 #else
 #  define CALL_GL(exp) exp

--- a/libautoscoper/src/CoordFrame.hpp
+++ b/libautoscoper/src/CoordFrame.hpp
@@ -42,6 +42,7 @@
 #ifndef XROMM_COORD_FRAME_HPP
 #define XROMM_COORD_FRAME_HPP
 
+#include <ostream>
 #include <string>
 #include <Vector.hpp>
 

--- a/libautoscoper/src/Tracker.hpp
+++ b/libautoscoper/src/Tracker.hpp
@@ -42,6 +42,7 @@
 #ifndef XROMM_TRACKER_H
 #define XROMM_TRACKER_H
 
+#include <iostream>
 #include <vector>
 #include <string>
 

--- a/libautoscoper/src/VolumeTransform.cpp
+++ b/libautoscoper/src/VolumeTransform.cpp
@@ -1,6 +1,6 @@
 
 #include "VolumeTransform.hpp"
-#include <istream>
+#include <iostream>
 namespace xromm {
 
 void VolumeTransform::setCurrentCurveSet(const int& idx)


### PR DESCRIPTION
Fix iostream include hygiene across C++ files (transitive include removed from VTK, see https://discourse.vtk.org/t/important-update-standard-iostream-availability-from-vtk/16171)

Add missing <iostream>/<ostream> includes to files that use std::cerr, std::cout, std::ostream, or std::endl without an explicit include. Also correct <istream> -> <iostream> in VolumeTransform.cpp and qualify bare cerr/endl with std:: in the GLWidget.h CALL_GL macro.