### PR TITLE
COMP: Remove /utf-8 from Windows NVCC flags

### DIFF
--- a/libautoscoper/CMakeLists.txt
+++ b/libautoscoper/CMakeLists.txt
@@ -98,6 +98,14 @@ if(Autoscoper_RENDERING_BACKEND STREQUAL "CUDA")
   enable_language(CUDA)
   find_package(CUDAToolkit REQUIRED)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/CMakeLists.txt)
+  if(WIN32)
+    # VTK passes /utf-8 flag to host compiler on Windows. NVCC does not
+    # handle this and must be explicitly instructed to forward it to the host
+    # compiler with -Xcompiler.
+    string(REPLACE "-utf-8" "" CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
+    string(REPLACE "/utf-8" "" CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=\"/utf-8\"")
+  endif()
   add_library(libautoscoper STATIC ${libautoscoper_SOURCES} ${libautoscoper_HEADERS} ${cuda_HEADERS} ${cuda_SOURCES} ${cuda_KERNEL_HEADERS} ${cuda_KERNEL})
   target_include_directories(libautoscoper PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu/cuda/cutil)
   target_link_libraries(libautoscoper PUBLIC


### PR DESCRIPTION
Attempting to address the errors here https://slicer.cdash.org/builds/4332597/build

It seems that the utf-8 flag comes from VTK https://github.com/Kitware/VTK/blob/v9.6.2/CMake/vtkCompilerPlatformFlags.cmake#L192-L196 and they are implicitly copied to CMAKE_CUDA_FLAGS.

I'm not totally confident this will fix the issue in CI, because this change might not pass any other cuda flags through to nvcc, which would probably cause issues when it invokes the host compiler. I *think* it will be okay, because those things *should* be defined as target properties, but I'm not sure that they actually are.

cc @bpaniagua 